### PR TITLE
Adding stream metadata to cmus-remote -Q

### DIFF
--- a/ui_curses.c
+++ b/ui_curses.c
@@ -1266,28 +1266,6 @@ static void do_update_commandline(void)
 	}
 }
 
-/* lock player_info! */
-static const char *get_stream_title(void)
-{
-	static char stream_title[255 * 16 + 1];
-	char *ptr, *title;
-
-	ptr = strstr(player_info.metadata, "StreamTitle='");
-	if (ptr == NULL)
-		return NULL;
-	ptr += 13;
-	title = ptr;
-	while (*ptr) {
-		if (*ptr == '\'' && *(ptr + 1) == ';') {
-			memcpy(stream_title, title, ptr - title);
-			stream_title[ptr - title] = 0;
-			return stream_title;
-		}
-		ptr++;
-	}
-	return NULL;
-}
-
 static void set_title(const char *title)
 {
 	if (!set_term_title)
@@ -1427,6 +1405,28 @@ static void post_update(void)
 			curs_set(0);
 		}
 	}
+}
+
+/* lock player_info! */
+const char *get_stream_title(void)
+{
+	static char stream_title[255 * 16 + 1];
+	char *ptr, *title;
+
+	ptr = strstr(player_info.metadata, "StreamTitle='");
+	if (ptr == NULL)
+		return NULL;
+	ptr += 13;
+	title = ptr;
+	while (*ptr) {
+		if (*ptr == '\'' && *(ptr + 1) == ';') {
+			memcpy(stream_title, title, ptr - title);
+			stream_title[ptr - title] = 0;
+			return stream_title;
+		}
+		ptr++;
+	}
+	return NULL;
 }
 
 void update_titleline(void)

--- a/ui_curses.h
+++ b/ui_curses.h
@@ -62,4 +62,7 @@ void enter_search_backward_mode(void);
 
 int track_format_valid(const char *format);
 
+/* lock player_info ! */
+const char *get_stream_title(void);
+
 #endif


### PR DESCRIPTION
Hi, currently if you play a stream using cmus, you can see the artist/album/title information in the curses display, but the same information is not available by querying the server with `cmus-remote -Q`.

I wanted to be able to get to that information, and I think my way makes sense ... basically I've added a new field (stream) to the output of `cmus-remote -Q` which contains the stream metadata.

Here's an example of how this looks:

```
% cmus-remote -Q                                              
status playing
file http://stream.mybox.com
duration -1
position 2
tag title Some Cool stream
tag genre Some Cool Genre
tag comment http://some-stream-url
stream Fila Brazillia - Brazilification Remixes 95-99 (CD2) - Freakpower / New Direction (Fila Brazillia Mix) # <- NEW!
set aaa_mode album
set continue true
set play_library false
set play_sorted true
set replaygain disabled
set replaygain_limit true
set replaygain_preamp 6.000000
set repeat true
set repeat_current false
set shuffle false
set softvol false
set vol_left 16
set vol_right 16
```

Incidentally, this field can also be used as a boolean to let a client know whether or not a stream is being played.  Please let me know if you have any questions, and I hope the changes I made are acceptable.
