### PR TITLE
rewind_offset

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -948,6 +948,12 @@ replaygain_preamp (6.0)
 resume (false)
 	Resume playback on startup.
 
+rewind_offset (5) [-1-9999]
+	If the position of the current track is smaller than rewind_offset,
+	player_prev jumps to the previous track. Otherwise, player_prev jumps
+	to the beginning of the current track. If rewind_offset=-1, player_prev
+	always jumps to the previous track.
+
 scroll_offset (2) [0-9999]
 	Minimal number of screen lines to keep above and below the cursor.
 

--- a/command_mode.c
+++ b/command_mode.c
@@ -1295,7 +1295,11 @@ static void cmd_p_play(char *arg)
 
 static void cmd_p_prev(char *arg)
 {
-	cmus_prev();
+	if (rewind_offset < 0 || player_info.pos < rewind_offset) {
+		cmus_prev();
+	} else {
+		player_play();
+	}
 }
 
 static void cmd_p_stop(char *arg)

--- a/options.c
+++ b/options.c
@@ -74,6 +74,7 @@ int shuffle = 0;
 int display_artist_sort_name;
 int smart_artist_sort = 1;
 int scroll_offset = 2;
+int rewind_offset = 5;
 int skip_track_info = 0;
 
 int colors[NR_COLORS] = {
@@ -236,6 +237,19 @@ static void set_scroll_offset(unsigned int id, const char *buf)
 
 	if (parse_int(buf, 0, 9999, &offset))
 		scroll_offset = offset;
+}
+
+static void get_rewind_offset(unsigned int id, char *buf)
+{
+	buf_int(buf, rewind_offset);
+}
+
+static void set_rewind_offset(unsigned int id, const char *buf)
+{
+	int offset;
+
+	if (parse_int(buf, -1, 9999, &offset))
+		rewind_offset = offset;
 }
 
 static void get_id3_default_charset(unsigned int id, char *buf)
@@ -1133,6 +1147,7 @@ static const struct {
 	DN_FLAGS(device, OPT_PROGRAM_PATH)
 	DN(buffer_seconds)
 	DN(scroll_offset)
+	DN(rewind_offset)
 	DT(confirm_run)
 	DT(continue)
 	DT(smart_artist_sort)

--- a/options.h
+++ b/options.h
@@ -134,6 +134,7 @@ extern int shuffle;
 extern int display_artist_sort_name;
 extern int smart_artist_sort;
 extern int scroll_offset;
+extern int rewind_offset;
 extern int skip_track_info;
 
 extern const char * const aaa_mode_names[];


### PR DESCRIPTION
https://github.com/cmus/cmus/issues/22

rewind_offset (5) [-1-9999]
  If the position of the current track is smaller than rewind_offset,
  player_prev jumps to the previous track. Otherwise, player_prev jumps
  to the beginning of the current track. If rewind_offset=-1, player_prev
  always jumps to the previous track.
