### PR TITLE
make enum and array in options.c independent of order

### DIFF
--- a/options.c
+++ b/options.c
@@ -217,6 +217,8 @@ static const struct {
 	[FMT_TRACKWIN]		= { "format_trackwin"	, "%3n. %t%= %y %d "			},
 	[FMT_TRACKWIN_VA]	= { "format_trackwin_va", "%3n. %t (%a)%= %y %d "		},
 
+	[NR_FMTS] =
+
 	{ "lib_sort", "albumartist date album discnumber tracknumber title filename" },
 	{ "pl_sort", "" },
 	{ "id3_default_charset", "ISO-8859-1" },


### PR DESCRIPTION
When the enum `format_id` and the array `str_defaults` are used in the functions `options_add` and `options_load`,  both have to be in the same order for the code to work. The code breaks silently if this is not the case.

This patch removes this dependence and moves the array (which is currently 1000 lines away) right next to the enum to make the connection between these two structures clear.
