### PR TITLE
fix seeking in ffmpeg

### DIFF
--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -476,25 +476,9 @@ static int ffmpeg_seek(struct input_plugin_data *ip_data, double offset)
 
 #if (LIBAVFORMAT_VERSION_INT >= ((53<<16) + (25<<8) + 0))
 	{
-		AVFrame *frame = avcodec_alloc_frame();
-		AVPacket pkt;
-		int got_frame=0;
-		av_new_packet(&pkt, 0);
-		/* This is specified in
-		 * http://ffmpeg.org/doxygen/trunk/group__lavc__decoding.html#ga834bb1b062fbcc2de4cf7fb93f154a3e
-		 * Quote:
-		 * Flushing is done by calling this function with packets with
-		 * avpkt->data set to NULL and avpkt->size set to 0 until it
-		 * stops returning samples. */
-		pkt.data = NULL;
-		pkt.size = 0;
-		do {
-			avcodec_decode_audio4(priv->codec_context, frame, &got_frame, &pkt);
-		} while (got_frame);
+		avcodec_flush_buffers(priv->codec_context);
 		/* Force reading a new packet in next ffmpeg_fill_buffer(). */
 		priv->input->curr_pkt_size = 0;
-		av_free_packet(&pkt);
-		avcodec_free_frame(&frame);
 	}
 #endif
 


### PR DESCRIPTION
When playing with ffmpeg plugin and user seeks to the beginning of track, cmus
wouldn't immediately start from the beginning, but would continue playing for
a while (about 3~5 seconds), and then suddenly jump to the beginning.

This problem only appears when decoding some specific types of audio file, like
APE. If using ffmpeg plugin to decode FLAC or other types, there's no visible
problem.

A segment of code is added in ffmpeg_seek() to flush the decoded output and
reset the input buffer. This should make it jump immediately, but the current
duration after jump is still not precise.
