### PR TITLE
Select topmost entry in tree win on start

### DIFF
--- a/cmus.c
+++ b/cmus.c
@@ -164,7 +164,7 @@ enum file_type cmus_detect_ft(const char *name, char **ret)
 	return FILE_TYPE_FILE;
 }
 
-void cmus_add(add_ti_cb add, const char *name, enum file_type ft, int jt, int force)
+static void cmus_add_generic(add_ti_cb add, const char *name, enum file_type ft, int jt, int force, void (*job_cb)(void *data))
 {
 	struct add_data *data = xnew(struct add_data, 1);
 
@@ -172,7 +172,17 @@ void cmus_add(add_ti_cb add, const char *name, enum file_type ft, int jt, int fo
 	data->name = xstrdup(name);
 	data->type = ft;
 	data->force = force;
-	worker_add_job(jt, do_add_job, free_add_job, data);
+	worker_add_job(jt, job_cb, free_add_job, data);
+}
+
+void cmus_add(add_ti_cb add, const char *name, enum file_type ft, int jt, int force)
+{
+	cmus_add_generic(add, name, ft, jt, force, do_add_job);
+}
+
+void cmus_load_lib(const char *name)
+{
+	cmus_add_generic(lib_add_track, name, FILE_TYPE_PL, JOB_TYPE_LIB, 0, do_load_lib_job);
 }
 
 static int save_ext_playlist_cb(void *data, struct track_info *ti)

--- a/cmus.h
+++ b/cmus.h
@@ -73,6 +73,7 @@ enum file_type cmus_detect_ft(const char *name, char **ret);
  * returns immediately, actual work is done in the worker thread.
  */
 void cmus_add(add_ti_cb, const char *name, enum file_type ft, int jt, int force);
+void cmus_load_lib(const char *name);
 
 int cmus_save(for_each_ti_cb for_each_ti, const char *filename);
 int cmus_save_ext(for_each_ti_cb for_each_ti, const char *filename);

--- a/job.c
+++ b/job.c
@@ -315,6 +315,13 @@ void do_add_job(void *data)
 	jd = NULL;
 }
 
+void do_load_lib_job(void *data)
+{
+	do_add_job(data);
+	window_goto_top(lib_tree_win);
+	window_goto_top(lib_track_win);
+}
+
 void free_add_job(void *data)
 {
 	struct add_data *d = data;

--- a/job.h
+++ b/job.h
@@ -40,6 +40,7 @@ struct update_cache_data {
 };
 
 void do_add_job(void *data);
+void do_load_lib_job(void *data);
 void free_add_job(void *data);
 void do_update_job(void *data);
 void free_update_job(void *data);

--- a/ui_curses.c
+++ b/ui_curses.c
@@ -2331,7 +2331,7 @@ static void init_all(void)
 	}
 
 	cmus_add(pl_add_track, pl_autosave_filename, FILE_TYPE_PL, JOB_TYPE_PL, 0);
-	cmus_add(lib_add_track, lib_autosave_filename, FILE_TYPE_PL, JOB_TYPE_LIB, 0);
+	cmus_load_lib(lib_autosave_filename);
 }
 
 static void exit_all(void)


### PR DESCRIPTION
When cmus starts the first entry in lib.pl is automatically selected in
the tree view. This entry is determined by the lib_sort option. This
patch makes cmus automatically select the topmost entry instead.
