### PR TITLE
use mp4 genreType if necessary

### DIFF
--- a/id3.c
+++ b/id3.c
@@ -1280,3 +1280,10 @@ char *id3_get_comment(struct id3tag *id3, enum id3_key key)
 	}
 	return NULL;
 }
+
+char const *id3_get_genre(uint16_t id)
+{
+	if (id >= NR_GENRES)
+		return NULL;
+	return genres[id];
+}

--- a/id3.h
+++ b/id3.h
@@ -19,6 +19,8 @@
 #ifndef _ID3_H
 #define _ID3_H
 
+#include <stdint.h>
+
 /* flags for id3_read_tags */
 #define ID3_V1	(1 << 0)
 #define ID3_V2	(1 << 1)
@@ -72,5 +74,7 @@ void id3_free(struct id3tag *id3);
 
 int id3_read_tags(struct id3tag *id3, int fd, unsigned int flags);
 char *id3_get_comment(struct id3tag *id3, enum id3_key key);
+
+char const *id3_get_genre(uint16_t id);
 
 #endif

--- a/mp4.c
+++ b/mp4.c
@@ -19,6 +19,7 @@
 #include "ip.h"
 #include "xmalloc.h"
 #include "debug.h"
+#include "id3.h"
 #include "file.h"
 #ifdef HAVE_CONFIG
 #include "config/mp4.h"
@@ -462,8 +463,13 @@ static int mp4_read_comments(struct input_plugin_data *ip_data,
 		comments_add_const(&c, "album", tags->album);
 	if (tags->name)
 		comments_add_const(&c, "title", tags->name);
-	if (tags->genre)
+	if (tags->genre) {
 		comments_add_const(&c, "genre", tags->genre);
+	} else if (tags->genreType) {
+		char const *genre = id3_get_genre(*tags->genreType - 1);
+		if (genre)
+			comments_add_const(&c, "genre", genre);
+	}
 	if (tags->releaseDate && strcmp(tags->releaseDate, "0") != 0)
 		comments_add_const(&c, "date", tags->releaseDate);
 	if (tags->compilation)


### PR DESCRIPTION
I don't know if `*tags->genreType - 1` is actually the correct way to do this but it worked for the one file from #80. There is also a field called `genreID` which might or might not be used by some files. I couldn't find any mp4v2 docs on these fields.
