### PR TITLE
Fix use-after-free in browser

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -327,19 +327,20 @@ void browser_up(void)
 		new = xstrndup(browser_dir, ptr - browser_dir);
 	}
 
-	if (browser_load(new)) {
-		error_msg("could not open directory '%s': %s\n", new, strerror(errno));
-		free(new);
-		return;
-	}
-	free(new);
-
-	/* remember last position */
+	/* remember old position */
 	ptr++;
 	len = strlen(ptr);
 	pos = xstrdup(ptr);
 
-	/* select */
+	if (browser_load(new)) {
+		error_msg("could not open directory '%s': %s\n", new, strerror(errno));
+		free(new);
+		free(pos);
+		return;
+	}
+	free(new);
+
+	/* select old position */
 	list_for_each_entry(e, &browser_head, node) {
 		if (strncmp(e->name, pos, len) == 0 &&
 		    (e->name[len] == '/' || e->name[len] == '\0')) {


### PR DESCRIPTION
browser_load frees browser_dir but ptr, which points to a substring of
browser_dir, is used afterwards.

---

It's funny that this hasn't ever crashed before. Heap fragmentation, I guess? I'm compiling with  -fsanitize=address in both CFLAGS and LFLAGS now which adds such checks to the code (at a 2x slowdown).
