### PR TITLE
Trim release dates to year

### DIFF
--- a/ui_curses.c
+++ b/ui_curses.c
@@ -284,8 +284,8 @@ static struct format_option track_fopts[NR_TFS + 1] = {
 	DEF_FO_INT('D', "discnumber", 1),
 	DEF_FO_INT('n', "tracknumber", 1),
 	DEF_FO_STR('t', "title", 0),
-	DEF_FO_STR('y', "date", 1),
-	DEF_FO_STR('\0', "originaldate", 1),
+	DEF_FO_INT('y', "date", 1),
+	DEF_FO_INT('\0', "originaldate", 1),
 	DEF_FO_STR('g', "genre", 0),
 	DEF_FO_STR('c', "comment", 0),
 	DEF_FO_TIME('d', "duration", 0),
@@ -614,7 +614,7 @@ static void fill_track_fopts_track_info(struct track_info *info)
 	fopt_set_int(&track_fopts[TF_DISC], info->discnumber, info->discnumber == -1);
 	fopt_set_int(&track_fopts[TF_TRACK], info->tracknumber, info->tracknumber == -1);
 	fopt_set_str(&track_fopts[TF_TITLE], info->title);
-	fopt_set_str(&track_fopts[TF_YEAR], keyvals_get_val(info->comments, "date"));
+	fopt_set_int(&track_fopts[TF_YEAR], info->date / 10000, info->date <= 0);
 	fopt_set_str(&track_fopts[TF_GENRE], info->genre);
 	fopt_set_str(&track_fopts[TF_COMMENT], info->comment);
 	fopt_set_time(&track_fopts[TF_DURATION], info->duration, info->duration == -1);
@@ -622,7 +622,7 @@ static void fill_track_fopts_track_info(struct track_info *info)
 	fopt_set_double(&track_fopts[TF_RG_TRACK_PEAK], info->rg_track_peak, isnan(info->rg_track_peak));
 	fopt_set_double(&track_fopts[TF_RG_ALBUM_GAIN], info->rg_album_gain, isnan(info->rg_album_gain));
 	fopt_set_double(&track_fopts[TF_RG_ALBUM_PEAK], info->rg_album_peak, isnan(info->rg_album_peak));
-	fopt_set_str(&track_fopts[TF_ORIGINALYEAR], keyvals_get_val(info->comments, "originaldate"));
+	fopt_set_int(&track_fopts[TF_ORIGINALYEAR], info->date / 10000, info->originaldate <= 0);
 	fopt_set_int(&track_fopts[TF_BITRATE], (int) (info->bitrate / 1000. + 0.5), info->bitrate == -1);
 	fopt_set_str(&track_fopts[TF_CODEC], info->codec);
 	fopt_set_str(&track_fopts[TF_CODEC_PROFILE], info->codec_profile);


### PR DESCRIPTION
This makes it consistent with how dates are handled in expr.c

Most tag decoders trim the dates anyway (see e.g. fix_date() in id3.c and ffmpeg_read_comments() in ffmpeg.c). For decoders that don't (e.g. flac.c), the sorted library view looks broken when full dates are intermingled with year-only dates:

``` text
 2. En lintinbluitin faran...             04:46 Falkenbach                            2013-11-01 Asa                                   Metal - Folk
 3. Return to Ultima Thule                03:25 Falkenbach                            2013-11-01 Asa                                   Metal - Folk
 4. I svertar sunna luihtint              05:59 Falkenbach                            2013-11-01 Asa                                   Metal - Folk
 1. Introduction                          01:42 Fall                                  2009 Black Autumnal Void                   Metal - Black
 2. Trance in Pain                        07:33 Fall                                  2009 Black Autumnal Void                   Metal - Black
 3. Black Autumnal Void                   06:14 Fall                                  2009 Black Autumnal Void                   Metal - Black
```
