### PR TITLE
Add solarized light/dark themes

### DIFF
--- a/data/solarized-dark.theme
+++ b/data/solarized-dark.theme
@@ -1,0 +1,49 @@
+# colors from solarized: http://ethanschoonover.com/solarized
+# default text color
+set color_win_fg=default
+
+# overall background color
+set color_win_bg=default
+
+# command-line colors
+set color_cmdline_bg=default
+set color_cmdline_fg=default
+set color_error=160
+set color_info=136
+set color_separator=240
+
+# bottom status line
+set color_statusline_bg=0
+set color_statusline_fg=37
+
+# bottom title line
+set color_titleline_bg=0
+set color_titleline_fg=136
+
+# top title area
+set color_win_title_bg=0
+set color_win_title_fg=64
+##### playing file colors ######################################################
+# unselected currently playing track's text
+set color_win_cur=33
+
+# active selection for currently playing track
+set color_win_cur_sel_bg=0
+set color_win_cur_sel_fg=33
+
+# inactive selection for currently playing track
+set color_win_inactive_cur_sel_bg=0
+set color_win_inactive_cur_sel_fg=125
+
+##### non-playing file colors ##################################################
+# active selection
+set color_win_sel_bg=0
+set color_win_sel_fg=166
+
+# inactive selection
+set color_win_inactive_sel_bg=0
+set color_win_inactive_sel_fg=125
+
+##### file browser view colors #################################################
+# directory listing color
+set color_win_dir=33

--- a/data/solarized-light.theme
+++ b/data/solarized-light.theme
@@ -1,0 +1,49 @@
+# colors from solarized: http://ethanschoonover.com/solarized
+# default text color
+set color_win_fg=default
+
+# overall background color
+set color_win_bg=default
+
+# command-line colors
+set color_cmdline_bg=default
+set color_cmdline_fg=default
+set color_error=160
+set color_info=136
+set color_separator=245
+
+# bottom status line
+set color_statusline_bg=0
+set color_statusline_fg=37
+
+# bottom title line
+set color_titleline_bg=0
+set color_titleline_fg=136
+
+# top title area
+set color_win_title_bg=0
+set color_win_title_fg=64
+##### playing file colors ######################################################
+# unselected currently playing track's text
+set color_win_cur=33
+
+# active selection for currently playing track
+set color_win_cur_sel_bg=0
+set color_win_cur_sel_fg=33
+
+# inactive selection for currently playing track
+set color_win_inactive_cur_sel_bg=0
+set color_win_inactive_cur_sel_fg=125
+
+##### non-playing file colors ##################################################
+# active selection
+set color_win_sel_bg=0
+set color_win_sel_fg=166
+
+# inactive selection
+set color_win_inactive_sel_bg=0
+set color_win_inactive_sel_fg=125
+
+##### file browser view colors #################################################
+# directory listing color
+set color_win_dir=33


### PR DESCRIPTION
Requires your terminal to be set to solarized:
https://github.com/altercation/solarized

More info from solarized: http://ethanschoonover.com/solarized

Themes originally based on data/green-mono-88.theme
