### PR TITLE
fixed segmentation fault in status command with http stream

### DIFF
--- a/server.c
+++ b/server.c
@@ -109,7 +109,7 @@ static int cmd_status(struct client *client)
 			title_buf = to_utf8(title, icecast_default_charset);
 			// we have a stream title (probably artist/track/album info)
 			gbuf_addf(&buf, "stream %s\n", escape(title_buf));
-		} else {
+		} else if (ti->comment != NULL) {
 			// fallback to the radio station name
 			gbuf_addf(&buf, "stream %s\n", escape(ti->comment));
 		}


### PR DESCRIPTION
Fixes https://github.com/cmus/cmus/issues/73

Steps to reproduce:

```
cmus-remote ‘http://rpod.ru/get/303797/271934/download/Boris%20Grebenshchikov%20-%20Aerostat%20Radio%20vol.420.mp3'
cmus-remote --play
cmus-remote --query
```

Version:

```
cmus v2.5.0-93-gb47e190
```

reproduce on linux and mac os

GDB:

```
Linux:
Program received signal SIGSEGV, Segmentation fault.
0xb6dfa834 in strlen () from /lib/arm-linux-gnueabihf/libc.so.6

(gdb) where
#0  0xb6dfa834 in strlen () from /lib/arm-linux-gnueabihf/libc.so.6
#1  0x00026458 in escape (str=0x0) at misc.c:94
#2  0x0002dbcc in cmd_status (client=0x97b70) at server.c:111
#3  read_commands (client=0x97b70) at server.c:242
#4  0x0002dd84 in server_serve (client=<optimized out>) at server.c:295
#5  0x00036d88 in main_loop () at ui_curses.c:2183
#6  0x00011a44 in main (argc=<optimized out>, argv=0x0) at ui_curses.c:2481

---
Mac OS:

Reading symbols for shared libraries .
Program received signal EXC_BAD_ACCESS, Could not access memory.
Reason: KERN_INVALID_ADDRESS at address: 0x0000000000000000
0x00007fff918c1812 in strlen ()
(gdb) where
#0  0x00007fff918c1812 in strlen ()
#1  0x000000010001819f in escape (str=0x0) at misc.c:93
#2  0x0000000100020b3d in read_commands [inlined] () at /Users/msa/var/src/cmus/server.c:114
#3  0x0000000100020b3d in server_serve (client=<value temporarily unavailable, due to optimizations>) at server.c:295
#4  0x0000000100029c7f in main (argc=0, argv=0x7fff5fbff968) at ui_curses.c:2158
```
