### PR TITLE
Fix 7h maximal mp3 runtime

### DIFF
--- a/player.c
+++ b/player.c
@@ -99,12 +99,12 @@ static pthread_mutex_t consumer_mutex = CMUS_MUTEX_INITIALIZER;
 static pthread_cond_t consumer_playing = CMUS_COND_INITIALIZER;
 static int consumer_running = 1;
 static enum consumer_status consumer_status = CS_STOPPED;
-static unsigned int consumer_pos = 0;
+static unsigned long consumer_pos = 0;
 
 /* for replay gain and soft vol
  * usually same as consumer_pos, sometimes less than consumer_pos
  */
-static unsigned int scale_pos;
+static unsigned long scale_pos;
 static double replaygain_scale = 1.0;
 
 /* locking {{{ */


### PR DESCRIPTION
7h = 25200 seconds
buffer_second_size = 176400
25200 \* 176400 = 4445280000 > UINT32_MAX
