### PR TITLE
Change URL for cmus. Add note to mailing list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 cmus — C\* Music Player
 =======================
 
-http://cmus.github.io/
+https://cmus.github.io/
 
 [![Build Status](https://travis-ci.org/cmus/cmus.png?branch=master)](https://travis-ci.org/cmus/cmus)
 
@@ -86,7 +86,7 @@ http://lists.sourceforge.net/lists/listinfo/cmus-devel
 The list is open but moderated (you can post to the list without
 subscribing but it's not recommended because I have to accept each email
 from non-subscribed users).  Traffic of the list is extremely low.
-Please use the [issues](http://github.com/cmus/cmus/issues) page for any problems, suggestions, or bug reports.
+Please use the [issues](https://github.com/cmus/cmus/issues) page for any problems, suggestions, or bug reports.
 
 Reporting Bugs
 --------------


### PR DESCRIPTION
This is an README update that is part of issue #70. 

It release the sf.net url with the org github page,  as well as adds a note about the mailing list.
