### PR TITLE
Add min buffer size.

### DIFF
--- a/jack.c
+++ b/jack.c
@@ -38,7 +38,7 @@
 
 #define CHANNELS 2
 #define BUFFER_MULTIPLYER (sizeof(jack_default_audio_sample_t) * 16)
-#define BUFFER_SIZE_MIN 8192
+#define BUFFER_SIZE_MIN 16384
 
 static struct {
 	char* server_name;


### PR DESCRIPTION
Buffer size is calculated based on the jackd's period. When the period
gets small, the calculated buffer size does not work well with cmus,
causing dropouts. This commit adds a minimum buffer size of 8192, which
seems to work well.
