### PR TITLE
play_queue doesn't update any other views when changing tracks

### DIFF
--- a/cmus.c
+++ b/cmus.c
@@ -75,7 +75,7 @@ void cmus_next(void)
 	struct track_info *info;
 
 	editable_lock();
-	info = play_queue_remove();
+	info = play_queue_goto_next();
 	if (info == NULL) {
 		if (play_library) {
 			info = lib_goto_next();

--- a/play_queue.c
+++ b/play_queue.c
@@ -20,6 +20,7 @@
 #include "editable.h"
 #include "track.h"
 #include "xmalloc.h"
+#include "lib.h"
 
 struct editable pq_editable;
 
@@ -61,6 +62,17 @@ struct track_info *play_queue_remove(void)
 		editable_remove_track(&pq_editable, t);
 	}
 
+	return info;
+}
+
+struct track_info *play_queue_goto_next(void) {
+	struct track_info *info = NULL;
+	info = play_queue_remove();
+	if (info) {
+		struct tree_track *track = NULL;
+		track = lib_find_track(info);
+		if (track) lib_set_track(track);
+	}
 	return info;
 }
 

--- a/play_queue.h
+++ b/play_queue.h
@@ -28,6 +28,7 @@ void play_queue_init(void);
 void play_queue_append(struct track_info *ti);
 void play_queue_prepend(struct track_info *ti);
 struct track_info *play_queue_remove(void);
+struct track_info *play_queue_goto_next(void);
 int play_queue_for_each(int (*cb)(void *data, struct track_info *ti), void *data);
 
 #endif

--- a/ui_curses.c
+++ b/ui_curses.c
@@ -2217,7 +2217,7 @@ static int get_next(struct track_info **ti)
 	struct track_info *info;
 
 	editable_lock();
-	info = play_queue_remove();
+	info = play_queue_goto_next();
 	if (info == NULL) {
 		if (play_library) {
 			info = lib_goto_next();


### PR DESCRIPTION
Hi,

I've noticed that the main and track views are not updated when playing tracks from the queue. Bellow patch contains the code which updates those views on each play_queue track removal.
