### PR TITLE
Add support for combining diacritical marks

### DIFF
--- a/uchar.c
+++ b/uchar.c
@@ -181,6 +181,10 @@ int u_char_width(uchar u)
 	if (unlikely(u < 0x20))
 		goto control;
 
+	/* Combining Diacritical Marks */
+	if (u >= 0x300U && u <= 0x36fU)
+		goto zero;
+
 	if (u < 0x1100U)
 		goto narrow;
 


### PR DESCRIPTION
If there is a combining diacritical marks (such as in ю́ which is "\u044e\u0301", that is ' ́' on 'ю') in the title of a track, the right column (after %=) is one character too far left.
This fixes it.
