### PR TITLE
Use of the data type "sig_atomic_t" for a few variables

### DIFF
--- a/ui_curses.c
+++ b/ui_curses.c
@@ -86,7 +86,7 @@ char *tgoto(const char *cap, int col, int row);
 
 /* globals. documented in ui_curses.h */
 
-int cmus_running = 1;
+sig_atomic_t cmus_running = 1;
 int ui_initialized = 0;
 enum ui_input_mode input_mode = NORMAL_MODE;
 int cur_view = TREE_VIEW;
@@ -1805,7 +1805,7 @@ static void spawn_status_program(void)
 		free(argv[i]);
 }
 
-static int ctrl_c_pressed = 0;
+static sig_atomic_t ctrl_c_pressed = 0;
 
 static void sig_int(int sig)
 {
@@ -1817,7 +1817,7 @@ static void sig_shutdown(int sig)
 	cmus_running = 0;
 }
 
-static int needs_to_resize = 1;
+static sig_atomic_t needs_to_resize = 1;
 
 static void sig_winch(int sig)
 {

--- a/ui_curses.h
+++ b/ui_curses.h
@@ -29,7 +29,9 @@ enum ui_input_mode {
 	SEARCH_MODE
 };
 
-extern int cmus_running;
+#include <signal.h>
+
+extern sig_atomic_t cmus_running;
 extern int ui_initialized;
 extern enum ui_input_mode input_mode;
 extern int cur_view;


### PR DESCRIPTION
[The data type "sig_atomic_t"](http://www.gnu.org/software/libc/manual/html_node/Atomic-Types.html) can be used for the safe exchange of integral data with signal handlers.
