### PR TITLE
fix character width of halfwidth forms

### DIFF
--- a/uchar.c
+++ b/uchar.c
@@ -233,9 +233,17 @@ int u_char_width(uchar u)
 	if (u >= 0xff00U && u <= 0xff60U)
 		goto wide;
 
+	/* Halfwidth Forms */
+	if (u >= 0xff61U && u <= 0xffdfU)
+		goto narrow;
+
 	/* Fullwidth Forms */
 	if (u >= 0xffe0U && u <= 0xffe6U)
 		goto wide;
+
+	/* Halfwidth Forms */
+	if (u >= 0xffe8U && u <= 0xffeeU)
+		goto narrow;
 
 	/* CJK extra stuff */
 	if (u >= 0x20000U && u <= 0x2fffdU)


### PR DESCRIPTION
Handle halfwidth forms `<U+FF61..U+FFDF>` and `<U+FFE8..U+FFEE>` as narrow.
