### PR TITLE
Clarify selection in solarized theme

### DIFF
--- a/data/solarized-dark.theme
+++ b/data/solarized-dark.theme
@@ -32,7 +32,7 @@ set color_win_cur_sel_bg=0
 set color_win_cur_sel_fg=33
 
 # inactive selection for currently playing track
-set color_win_inactive_cur_sel_bg=0
+set color_win_inactive_cur_sel_bg=default
 set color_win_inactive_cur_sel_fg=125
 
 ##### non-playing file colors ##################################################
@@ -41,7 +41,7 @@ set color_win_sel_bg=0
 set color_win_sel_fg=166
 
 # inactive selection
-set color_win_inactive_sel_bg=0
+set color_win_inactive_sel_bg=default
 set color_win_inactive_sel_fg=125
 
 ##### file browser view colors #################################################

--- a/data/solarized-light.theme
+++ b/data/solarized-light.theme
@@ -32,7 +32,7 @@ set color_win_cur_sel_bg=0
 set color_win_cur_sel_fg=33
 
 # inactive selection for currently playing track
-set color_win_inactive_cur_sel_bg=0
+set color_win_inactive_cur_sel_bg=default
 set color_win_inactive_cur_sel_fg=125
 
 ##### non-playing file colors ##################################################
@@ -41,7 +41,7 @@ set color_win_sel_bg=0
 set color_win_sel_fg=166
 
 # inactive selection
-set color_win_inactive_sel_bg=0
+set color_win_inactive_sel_bg=default
 set color_win_inactive_sel_fg=125
 
 ##### file browser view colors #################################################


### PR DESCRIPTION
In the first view it can be hard to tell if your cursor is in the artist/album selection or track selection. Who even ported this colorscheme? :)
