### PR TITLE
OpenBSD sndio support

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -963,7 +963,7 @@ mouse (false)
 	NOTE: Mouse wheel scrolling can lag if cmus is compiled with
 	old version of Ncurses.
 
-output_plugin [roar, pulse, alsa, arts, oss, sun]
+output_plugin [roar, pulse, alsa, arts, oss, sndio, sun]
 	Name of output plugin.
 
 pl_sort () [`Sort Keys`]

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,7 @@ jack-objs		:= jack.lo
 arts-objs		:= arts.lo
 oss-objs		:= oss.lo mixer_oss.lo
 sun-objs		:= sun.lo mixer_sun.lo
+sndio-objs		:= sndio.lo
 ao-objs			:= ao.lo
 waveout-objs		:= waveout.lo
 roar-objs               := roar.lo
@@ -180,6 +181,7 @@ op-$(CONFIG_ALSA)	+= alsa.so
 op-$(CONFIG_JACK)	+= jack.so
 op-$(CONFIG_ARTS)	+= arts.so
 op-$(CONFIG_OSS)	+= oss.so
+op-$(CONFIG_SNDIO)	+= sndio.so
 op-$(CONFIG_SUN)	+= sun.so
 op-$(CONFIG_AO)		+= ao.so
 op-$(CONFIG_WAVEOUT)	+= waveout.so
@@ -190,6 +192,7 @@ $(alsa-objs): CFLAGS	+= $(ALSA_CFLAGS)
 $(jack-objs): CFLAGS	+= $(JACK_CFLAGS)
 $(arts-objs): CFLAGS	+= $(ARTS_CFLAGS)
 $(oss-objs):  CFLAGS	+= $(OSS_CFLAGS)
+$(sndio-objs): CFLAGS	+= $(SNDIO_CFLAGS)
 $(sun-objs):  CFLAGS	+= $(SUN_CFLAGS)
 $(ao-objs):   CFLAGS	+= $(AO_CFLAGS)
 $(waveout-objs): CFLAGS += $(WAVEOUT_CFLAGS)
@@ -209,6 +212,9 @@ arts.so: $(arts-objs) $(libcmus-y)
 
 oss.so: $(oss-objs) $(libcmus-y)
 	$(call cmd,ld_dl,$(OSS_LIBS))
+
+sndio.so: $(sndio-objs) $(libcmus-y)
+	$(call cmd,ld_dl,$(SNDIO_LIBS))
 
 sun.so: $(sun-objs) $(libcmus-y)
 	$(call cmd,ld_dl,$(SUN_LIBS))

--- a/configure
+++ b/configure
@@ -5,7 +5,7 @@
 check_cflags()
 {
 	check_cc_flag -std=gnu99 -pipe -Wall -Wshadow -Wcast-align -Wpointer-arith \
-		-Wwrite-strings -Wundef -Wmissing-prototypes -Wredundant-decls \
+		-Wwrite-strings -Wundef -Wmissing-prototypes \
 		-Wextra -Wno-sign-compare -Wformat-security
 
 	for i in -Wold-style-definition \
@@ -16,6 +16,16 @@ check_cflags()
 		check_cc_flag $i
 	done
 	return 0
+}
+
+check_sndio()
+{
+	case `uname -s` in
+	OpenBSD)
+		check_library SNDIO "" "-lsndio"
+		return $?
+	esac
+	return 1
 }
 
 check_compat()
@@ -466,6 +476,7 @@ Optional Features: y/n
   CONFIG_AO       	Libao cross-platform audio library              [auto]
   CONFIG_ARTS     	ARTS                                            [auto]
   CONFIG_OSS      	Open Sound System                               [auto]
+  CONFIG_SNDIO    	Sndio                                           [auto]
   CONFIG_SUN      	Sun Audio                                       [auto]
   CONFIG_WAVEOUT  	Windows Wave Out                                [auto]
   USE_FALLBACK_IP	Use a specific IP for every unrecognized	[n]
@@ -531,6 +542,7 @@ check check_samplerate CONFIG_SAMPLERATE
 check check_ao      CONFIG_AO
 check check_arts    CONFIG_ARTS
 check check_oss     CONFIG_OSS
+check check_sndio   CONFIG_SNDIO
 check check_sun     CONFIG_SUN
 check check_waveout CONFIG_WAVEOUT
 check check_roar    CONFIG_ROAR
@@ -569,6 +581,6 @@ CFLAGS="${CFLAGS} -DHAVE_CONFIG"
 
 makefile_vars bindir datadir libdir mandir exampledir
 makefile_vars CONFIG_CDIO CONFIG_FLAC CONFIG_MAD CONFIG_MIKMOD CONFIG_MODPLUG CONFIG_MPC CONFIG_VORBIS CONFIG_OPUS CONFIG_WAVPACK CONFIG_WAV CONFIG_MP4 CONFIG_AAC CONFIG_FFMPEG CONFIG_CUE CONFIG_VTX
-makefile_vars CONFIG_ROAR CONFIG_PULSE CONFIG_ALSA CONFIG_JACK CONFIG_SAMPLERATE CONFIG_AO CONFIG_ARTS CONFIG_OSS CONFIG_SUN CONFIG_WAVEOUT
+makefile_vars CONFIG_ROAR CONFIG_PULSE CONFIG_ALSA CONFIG_JACK CONFIG_SAMPLERATE CONFIG_AO CONFIG_ARTS CONFIG_OSS CONFIG_SNDIO CONFIG_SUN CONFIG_WAVEOUT
 
 generate_config_mk

--- a/configure
+++ b/configure
@@ -5,7 +5,7 @@
 check_cflags()
 {
 	check_cc_flag -std=gnu99 -pipe -Wall -Wshadow -Wcast-align -Wpointer-arith \
-		-Wwrite-strings -Wundef -Wmissing-prototypes \
+		-Wwrite-strings -Wundef -Wmissing-prototypes -Wredundant-decls \
 		-Wextra -Wno-sign-compare -Wformat-security
 
 	for i in -Wold-style-definition \

--- a/discid.c
+++ b/discid.c
@@ -40,7 +40,7 @@ char *get_default_cdda_device(void)
 	dev = discid_get_default_device();
 #endif
 	if (!dev)
-		dev = "/dev/rcd0c";
+		dev = "/dev/cdrom";
 	return xstrdup(dev);
 }
 

--- a/discid.c
+++ b/discid.c
@@ -40,7 +40,7 @@ char *get_default_cdda_device(void)
 	dev = discid_get_default_device();
 #endif
 	if (!dev)
-		dev = "/dev/cdrom";
+		dev = "/dev/rcd0c";
 	return xstrdup(dev);
 }
 

--- a/sndio.c
+++ b/sndio.c
@@ -1,0 +1,261 @@
+/*
+ * Copyright (C) 2011 Donovan "Tsomi" Watteau <tsoomi@gmail.com>
+ *
+ * Based on Thomas Pfaff's work for XMMS, and some suggestions from
+ * Alexandre Ratchov.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <sys/types.h>
+#include <sys/ioctl.h>
+#include <sys/audioio.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+#include <sndio.h>
+
+#include "op.h"
+#include "mixer.h"
+#include "sf.h"
+#include "xmalloc.h"
+
+static sample_format_t sndio_sf;
+static struct sio_par par;
+static struct sio_hdl *hdl = NULL;
+static int sndio_volume = 100;
+static int sndio_paused;
+
+static int sndio_mixer_set_volume(int l, int r)
+{
+	sndio_volume = l > r ? l : r;
+
+	if (hdl != NULL)
+		sio_setvol(hdl, sndio_volume * SIO_MAXVOL / 100);
+
+	return 0;
+}
+
+static int sndio_mixer_get_volume(int *l, int *r)
+{
+	*l = *r = sndio_volume;
+
+	return 0;
+}
+
+static int sndio_set_sf(sample_format_t sf)
+{
+	struct sio_par apar;
+
+	sndio_sf = sf;
+
+	sio_initpar(&par);
+
+	par.pchan = sf_get_channels(sndio_sf);
+	par.rate = sf_get_rate(sndio_sf);
+	sndio_paused = 0;
+
+	if (sf_get_signed(sndio_sf))
+		par.sig = 1;
+	else
+		par.sig = 0;
+
+	if (sf_get_bigendian(sndio_sf))
+		par.le = 0;
+	else
+		par.le = 1;
+
+	switch (sf_get_bits(sndio_sf)) {
+	case 16:
+		par.bits = 16;
+		break;
+	case 8:
+		par.bits = 8;
+		break;
+	default:
+		return -1;
+	}
+
+	par.appbufsz = par.rate * 300 / 1000;
+	apar = par;
+
+	if (!sio_setpar(hdl, &par))
+		return -1;
+
+	if (!sio_getpar(hdl, &par))
+		return -1;
+
+	if (apar.rate != par.rate || apar.pchan != par.pchan ||
+	    apar.bits != par.bits || (par.bits > 8 && apar.le != par.le) ||
+	    apar.sig != par.sig)
+		return -1;
+
+	sndio_mixer_set_volume(sndio_volume, sndio_volume);
+
+	if (!sio_start(hdl))
+		return -1;
+
+	return 0;
+}
+
+static int sndio_init(void)
+{
+	return 0;
+}
+
+static int sndio_exit(void)
+{
+	return 0;
+}
+
+static int sndio_close(void)
+{
+	if (hdl != NULL) {
+		sio_close(hdl);
+		hdl = NULL;
+	}
+
+	return 0;
+}
+
+static int sndio_open(sample_format_t sf, const channel_position_t *channel_map)
+{
+	hdl = sio_open(NULL, SIO_PLAY, 0);
+	if (hdl == NULL)
+		return -1;
+
+	if (sndio_set_sf(sf) == -1) {
+		sndio_close();
+		return -1;
+	}
+
+	return 0;
+}
+
+static int sndio_write(const char *buf, int cnt)
+{
+	size_t rc;
+
+	rc = sio_write(hdl, buf, cnt);
+	if (rc == 0)
+		return -1;
+
+	return rc;
+}
+
+static int op_sndio_set_option(int key, const char *val)
+{
+	return -OP_ERROR_NOT_OPTION;
+}
+
+static int op_sndio_get_option(int key, char **val)
+{
+	return -OP_ERROR_NOT_OPTION;
+}
+
+static int sndio_pause(void)
+{
+	if (!sndio_paused) {
+		sio_stop(hdl);
+		sndio_paused = 1;
+	}
+
+	return 0;
+}
+
+static int sndio_unpause(void)
+{
+	if (sndio_paused) {
+		sio_start(hdl);
+		sndio_paused = 0;
+	}
+
+	return 0;
+}
+
+static int sndio_buffer_space(void)
+{
+	/*
+	 * Do as if there's always some space and let sio_write() block.
+	 */
+	return par.bufsz * par.bps * par.pchan;
+}
+
+static int sndio_mixer_init(void)
+{
+	return OP_ERROR_SUCCESS;
+}
+
+static int sndio_mixer_exit(void)
+{
+	return OP_ERROR_SUCCESS;
+}
+
+static int sndio_mixer_open(int *volume_max)
+{
+	*volume_max = 100; 
+
+	return OP_ERROR_SUCCESS;
+}
+
+static int sndio_mixer_close(void)
+{
+	return OP_ERROR_SUCCESS;
+}
+
+static int sndio_mixer_set_option(int key, const char *val)
+{
+	return -OP_ERROR_NOT_OPTION;
+}
+
+static int sndio_mixer_get_option(int key, char **val)
+{
+	return -OP_ERROR_NOT_OPTION;
+}
+
+const struct output_plugin_ops op_pcm_ops = {
+	.init = sndio_init,
+	.exit = sndio_exit,
+	.open = sndio_open,
+	.close = sndio_close,
+	.write = sndio_write,
+	.pause = sndio_pause,
+	.unpause = sndio_unpause,
+	.buffer_space = sndio_buffer_space,
+	.set_option = op_sndio_set_option,
+	.get_option = op_sndio_get_option
+};
+
+const struct mixer_plugin_ops op_mixer_ops = {
+	.init = sndio_mixer_init,
+	.exit = sndio_mixer_exit,
+	.open = sndio_mixer_open,
+	.close = sndio_mixer_close,
+	.set_volume = sndio_mixer_set_volume,
+	.get_volume = sndio_mixer_get_volume,
+	.set_option = sndio_mixer_set_option,
+	.get_option = sndio_mixer_get_option
+};
+
+const char * const op_pcm_options[] = {
+	NULL
+};
+
+const char * const op_mixer_options[] = {
+	NULL
+};
+
+const int op_priority = 2;


### PR DESCRIPTION
This request includes most of the patches of the OpenBSD port. It includes a new output driver called sndio which is the default sound multiplexer in OpenBSD. Could someone test this on other platforms as well, so that these patches do not interfere?