### PR TITLE
Continue to 'cd ..' if parent directory not found.

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -334,6 +334,7 @@ void browser_up(void)
 
 	if (browser_load(new)) {
 		if (errno == ENOENT) {
+			free(browser_dir);
 			browser_dir = new;
 			free(pos);
 			browser_up();

--- a/browser.c
+++ b/browser.c
@@ -333,6 +333,12 @@ void browser_up(void)
 	pos = xstrdup(ptr);
 
 	if (browser_load(new)) {
+		if (errno == ENOENT) {
+			browser_dir = new;
+			free(pos);
+			browser_up();
+			return;
+		}
 		error_msg("could not open directory '%s': %s\n", new, strerror(errno));
 		free(new);
 		free(pos);


### PR DESCRIPTION
I just locked my cmus while adding/categorizing new music. I basically made the following steps:

```
mkdir /tmp/one/two
browse to /tmp/one/two in the Browser view
rm -r /tmp/one
try to browse to '..' in the Browser view: no such file or directory.
```

While this is perfectly correct, I think that I have locked the Browser view in this nonexistent directory.
I further think that it would be reasonable to try to browser_up() to the parent directory until an existing directory is found.
This pull request "works for me", but I'm not sure if I created a memory leak or something.