### PR TITLE
Enable -O2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ all: main plugins man
 include config.mk
 include scripts/lib.mk
 
+CFLAGS += -O2
 CFLAGS += -D_FILE_OFFSET_BITS=64
 
 FFMPEG_CFLAGS += $(shell pkg-config --cflags libswresample)


### PR DESCRIPTION
Some compiler flags require at least -O. To fix that, enable -O2.