### PR TITLE
fix pulseaudio alsa-sink 24s bug

### DIFF
--- a/alsa.c
+++ b/alsa.c
@@ -125,6 +125,7 @@ static int op_alsa_exit(void)
 static int alsa_set_hw_params(void)
 {
 	snd_pcm_hw_params_t *hwparams = NULL;
+	unsigned int buffer_time_max = 300 * 1000; /* us */
 	const char *cmd;
 	unsigned int rate;
 	int rc, dir;
@@ -133,6 +134,12 @@ static int alsa_set_hw_params(void)
 
 	cmd = "snd_pcm_hw_params_any";
 	rc = snd_pcm_hw_params_any(alsa_handle, hwparams);
+	if (rc < 0)
+		goto error;
+
+	cmd = "snd_pcm_hw_params_set_buffer_time_max";
+	rc = snd_pcm_hw_params_set_buffer_time_max(alsa_handle, hwparams,
+	                                           &buffer_time_max, &dir);
 	if (rc < 0)
 		goto error;
 


### PR DESCRIPTION
If you have `pulseaudio` and `pulseaudio-alsa` installed and when you start a new song, cmus will show that the song is already at the 24 seconds mark even though the song plays normally. When you seek, cmus will skip forward 24 seconds (+- what you're seeking.) 

If you start pulseaudio with verbose output, you can see the following message: 
```
D: [pulseaudio] alsa-util.c: Maximum hw buffer size is ___23777 ms___
D: [pulseaudio] alsa-util.c: Set buffer size first (to 88200 samples), period size second (to 88200 samples).
```

So it seems that when we're using the pulseaudio alsa sink, cmus will send alsa 24 seconds of audio before alsa tells it that the buffer is full. When you seek, cmus tells alsa to discard the buffer, which explains why we skip forward 24 seconds.

This patch tells alsa to buffer at most 100ms.

Closes #224 

PS: This bug was first reported in 2010: http://cmus-devel.narkive.com/gpx2XhqP/play-time-off-by-24s