### PR TITLE
 Add CMUS_SOCKET environment variable.

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -19,7 +19,8 @@ can be controlled from the outside via *cmus-remote*(1).
 @h1 OPTIONS
 
 --listen ADDR
-	Listen to ADDR (UNIX socket) instead of `$XDG_RUNTIME_DIR/cmus-socket`.
+	Listen to ADDR (UNIX socket) instead of `$CMUS_SOCKET` or 
+	`$XDG_RUNTIME_DIR/cmus-socket`.
 	ADDR is either a UNIX socket or host[:port].
 
 	*WARNING*: Using host[:port] is insecure even with password!
@@ -1436,6 +1437,9 @@ CMUS_CHARSET
 
 CMUS_HOME
 	Override cmus config directory (default: $XDG_CONFIG_HOME/cmus).
+
+CMUS_SOCKET
+	Override cmus socket path (default: $XDG_RUNTIME_DIR/cmus-socket).
 
 HOME
 	Full path of the user's home directory.

--- a/contrib/_cmus
+++ b/contrib/_cmus
@@ -41,7 +41,7 @@ case $service in
     ;;
   (cmus)
     _arguments \
-      '--listen[listen on ADDR instead of $XDG_RUNTIME_DIR/cmus-socket]:socket:_files' \
+      '--listen[listen on ADDR instead of $CMUS_SOCKET or $XDG_RUNTIME_DIR/cmus-socket]:socket:_files' \
       '--plugins[list available plugins and exit]'                        \
       '--help[display this help and exit]'                                \
       '--version[display version information]'

--- a/main.c
+++ b/main.c
@@ -231,7 +231,7 @@ static const char *usage =
 "   or: %s\n"
 "Control cmus through socket.\n"
 "\n"
-"      --server ADDR    connect using ADDR instead of $XDG_RUNTIME_DIR/cmus-socket\n"
+"      --server ADDR    connect using ADDR instead of $CMUS_SOCKET or $XDG_RUNTIME_DIR/cmus-socket\n"
 "                       ADDR is either a UNIX socket or host[:port]\n"
 "                       WARNING: using TCP/IP is insecure!\n"
 "      --passwd PASSWD  password to use for TCP/IP connection\n"

--- a/misc.c
+++ b/misc.c
@@ -218,10 +218,13 @@ int misc_init(void)
 	}
 	make_dir(cmus_config_dir);
 
-	if (xdg_runtime_dir == NULL) {
-		cmus_socket_path = xstrjoin(cmus_config_dir, "/socket");
-	} else {
-		cmus_socket_path = xstrjoin(xdg_runtime_dir, "/cmus-socket");
+	cmus_socket_path = get_non_empty_env("CMUS_SOCKET");
+	if (cmus_socket_path == NULL) {
+		if (xdg_runtime_dir == NULL) {
+			cmus_socket_path = xstrjoin(cmus_config_dir, "/socket");
+		} else {
+			cmus_socket_path = xstrjoin(xdg_runtime_dir, "/cmus-socket");
+		}
 	}
 	return 0;
 }

--- a/ui_curses.c
+++ b/ui_curses.c
@@ -2443,7 +2443,7 @@ static const char *usage =
 "Usage: %s [OPTION]...\n"
 "Curses based music player.\n"
 "\n"
-"      --listen ADDR   listen on ADDR instead of $XDG_RUNTIME_DIR/cmus-socket\n"
+"      --listen ADDR   listen on ADDR instead of $CMUS_SOCKET or $XDG_RUNTIME_DIR/cmus-socket\n"
 "                      ADDR is either a UNIX socket or host[:port]\n"
 "                      WARNING: using TCP/IP is insecure!\n"
 "      --plugins       list available plugins and exit\n"


### PR DESCRIPTION
This has basically the same effect as #68 .

Sometimes I am using several cmus instances at the same time and this is no longer possible since XDG_RUNTIME_DIR/cmus-socket is being used, so now the socket is located in CMUS_SOCKET if this env is set.