### PR TITLE
Add support for *.tak files as per cmus/cmus#319

### DIFF
--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -628,8 +628,8 @@ const struct input_plugin_ops ip_ops = {
 
 const int ip_priority = 30;
 const char *const ip_extensions[] = {
-	"ac3", "aif", "aifc", "aiff", "ape", "au", "mka", "shn", "tta", "wma",
-	"webm",
+	"ac3", "aif", "aifc", "aiff", "ape", "au", "mka", "shn", "tak", "tta",
+	"wma", "webm",
 	/* also supported by other plugins */
 	"aac", "fla", "flac", "m4a", "m4b", "mp+", "mp2", "mp3", "mp4", "mpc",
 	"mpp", "ogg", "wav", "wv",


### PR DESCRIPTION
I am not sure if we should check if FFmpeg's version supports TAK (as some relatively old versions do not). Let me know if that's the case.