### PR TITLE
Add support for *.aa files

### DIFF
--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -628,6 +628,9 @@ const struct input_plugin_ops ip_ops = {
 
 const int ip_priority = 30;
 const char *const ip_extensions[] = {
+#if (LIBAVFORMAT_VERSION_INT >= ((56<<16)+(40<<8)+0))
+	"aa",
+#endif
 	"ac3", "aif", "aifc", "aiff", "ape", "au", "mka", "shn", "tak", "tta",
 	"wma", "webm",
 	/* also supported by other plugins */


### PR DESCRIPTION
FFmpeg >= 2.8 (libavformat >=56.40.101) is required
for playing *.aa files.

A sample *.aa file can be downloaded from,
http://samples.ffmpeg.org/audible/