### PR TITLE
Fix HTTP-URI parsing bugs

### DIFF
--- a/http.c
+++ b/http.c
@@ -69,7 +69,7 @@ int http_parse_uri(const char *uri, struct http_uri *u)
 
 	/* [user[:pass]@] */
 	at = strchr(str, '@');
-	if (at) {
+	if (at && (!slash || at < slash)) {
 		/* user[:pass]@ */
 		host_start = at + 1;
 		colon = strchr(str, ':');
@@ -85,7 +85,7 @@ int http_parse_uri(const char *uri, struct http_uri *u)
 
 	/* host[:port] */
 	colon = strchr(host_start, ':');
-	if (colon) {
+	if (colon && (!slash || colon < slash)) {
 		/* host:port */
 		const char *start;
 		int port;

--- a/input.c
+++ b/input.c
@@ -171,6 +171,7 @@ static int do_http_get(struct http_get *hg, const char *uri, int redirections)
 
 	hg->headers = NULL;
 	hg->reason = NULL;
+	hg->proxy = NULL;
 	hg->code = -1;
 	hg->fd = -1;
 	if (http_parse_uri(uri, &hg->uri))


### PR DESCRIPTION
http_parse_uri doesn't work correctly when the URI's path contains an "at" or a colon. For example, the valid URI http://somedomain.com/path:withcolon fails to parse. Also, the proxy-value is undefined when http_parse_uri fails (e.g.: adding the stream http://somedomain.com:/ segfaults on my machine when free is called).