### PR TITLE
Fix for short terminal

### DIFF
--- a/ui_curses.c
+++ b/ui_curses.c
@@ -1874,8 +1874,8 @@ static void update(void)
 			h = LINES - 3;
 			if (w < 16)
 				w = 16;
-			if (h < 8)
-				h = 8;
+			if (h < 2)
+				h = 2;
 			editable_lock();
 			resize_tree_view(w, h);
 			window_set_nr_rows(lib_editable.win, h - 1);


### PR DESCRIPTION
Previously, if you resize your terminal to less than 8 lines, there was weird behavior when moving around or when the track changed such as the current track line disappearing or partially disappearing and then reappearing. This changes the min height to be 2 lines so that as long as there is space to show the current track line it does but if there is only one line display current selection.