### PR TITLE
adds gruvbox theme

### DIFF
--- a/data/gruvbox.theme
+++ b/data/gruvbox.theme
@@ -1,0 +1,49 @@
+# colors from gruvbox: https://github.com/morhetz/gruvbox
+# default text color
+set color_win_fg=default
+
+# overall background color
+set color_win_bg=default
+
+# command-line colors
+set color_cmdline_bg=default
+set color_cmdline_fg=default
+set color_error=124
+set color_info=172
+set color_separator=246
+
+# bottom status line
+set color_statusline_bg=237
+set color_statusline_fg=72
+
+# bottom title line
+set color_titleline_bg=236
+set color_titleline_fg=142
+
+# top title area
+set color_win_title_bg=246
+set color_win_title_fg=235
+##### playing file colors ######################################################
+# unselected currently playing track's text
+set color_win_cur=175
+
+# active selection for currently playing track
+set color_win_cur_sel_bg=237
+set color_win_cur_sel_fg=175
+
+# inactive selection for currently playing track
+set color_win_inactive_cur_sel_bg=236
+set color_win_inactive_cur_sel_fg=175
+
+##### non-playing file colors ##################################################
+# active selection
+set color_win_sel_bg=237
+set color_win_sel_fg=229
+
+# inactive selection
+set color_win_inactive_sel_bg=236
+set color_win_inactive_sel_fg=229
+
+##### file browser view colors #################################################
+# directory listing color
+set color_win_dir=229


### PR DESCRIPTION
Added a gruvbox theme for myself that might be worth including in the cmus master since it's a popular vim theme. Screenshot shows my cmus next to vim. I tried to make style choices so that it would look similar to vim.
![screen shot 2015-11-01 at 16 58 53](https://cloud.githubusercontent.com/assets/5876765/10872620/1c7c9748-80bb-11e5-9400-0e911da607cd.png)
