### PR TITLE
Added check for AudioUnit when configuring

### DIFF
--- a/configure
+++ b/configure
@@ -32,7 +32,7 @@ check_coreaudio()
 {
 	case `uname -s` in
 	Darwin)
-		check_library COREAUDIO "" "-framework CoreAudio"
+		check_library COREAUDIO "" "-framework CoreAudio -framework AudioUnit"
 		return $?
 	esac
 	return 1


### PR DESCRIPTION
This is a small commit to to check for the presence of AudioUnit framework when configuring the build. This PR is in relation to #374.