### PR TITLE
Multiple fixes

### DIFF
--- a/Doc/ttman.c
+++ b/Doc/ttman.c
@@ -851,6 +851,7 @@ static void process(void)
 		tokenize(buf, s.st_size);
 		normalize();
 	}
+	close(fd);
 	dump();
 }
 

--- a/Doc/ttman.c
+++ b/Doc/ttman.c
@@ -835,7 +835,7 @@ static void dump(void)
 
 static void process(void)
 {
-	struct stat s;
+	struct stat s = {};
 	const char *buf;
 	int fd;
 

--- a/cache.c
+++ b/cache.c
@@ -209,7 +209,7 @@ void cache_remove_ti(struct track_info *ti)
 static int read_cache(void)
 {
 	unsigned int size, offset = 0;
-	struct stat st;
+	struct stat st = {};
 	char *buf;
 	int fd;
 
@@ -219,7 +219,7 @@ static int read_cache(void)
 			return 0;
 		return -1;
 	}
-	fstat(fd,  &st);
+	fstat(fd, &st);
 	if (st.st_size < sizeof(cache_header))
 		goto close;
 	size = st.st_size;

--- a/cache.c
+++ b/cache.c
@@ -193,7 +193,7 @@ static void do_cache_remove_ti(struct track_info *ti, unsigned int hash)
 				hash_table[pos] = next;
 			}
 			total--;
-			track_info_unref(ti);
+			track_info_unref(&ti);
 			return;
 		}
 		prev = t;
@@ -502,7 +502,7 @@ struct track_info **cache_refresh(int *count, int force)
 
 			// clear cache-only entries
 			if (force && ti->ref == 1) {
-				track_info_unref(ti);
+				track_info_unref(&ti);
 				tis[i] = NULL;
 				continue;
 			}
@@ -512,7 +512,7 @@ struct track_info **cache_refresh(int *count, int force)
 				add_ti(new_ti, hash);
 
 				if (ti->ref == 1) {
-					track_info_unref(ti);
+					track_info_unref(&ti);
 					tis[i] = NULL;
 				} else {
 					track_info_ref(new_ti);
@@ -525,7 +525,7 @@ struct track_info **cache_refresh(int *count, int force)
 
 		// deleted
 		if (ti->ref == 1) {
-			track_info_unref(ti);
+			track_info_unref(&ti);
 			tis[i] = NULL;
 		} else {
 			ti->next = NULL;

--- a/command_mode.c
+++ b/command_mode.c
@@ -1106,7 +1106,7 @@ static void cmd_run(char *arg)
 	free_str_array(av);
 	free(argv);
 	for (i = 0; sel.tis[i]; i++)
-		track_info_unref(sel.tis[i]);
+		track_info_unref(&sel.tis[i]);
 	free(sel.tis);
 }
 
@@ -1179,7 +1179,7 @@ static void cmd_echo(char *arg)
 		return;
 
 	info_msg("%s%s%s", arg, sel_ti->filename, ptr);
-	track_info_unref(sel_ti);
+	track_info_unref(&sel_ti);
 }
 
 #define VF_RELATIVE	0x01

--- a/editable.c
+++ b/editable.c
@@ -381,14 +381,14 @@ int editable_for_each_sel(struct editable *e, int (*cb)(void *data, struct track
 	return rc;
 }
 
-void editable_update_track(struct editable *e, struct track_info *old, struct track_info *new)
+void editable_update_track(struct editable *e, struct track_info **old, struct track_info *new)
 {
 	struct list_head *item, *tmp;
 	int changed = 0;
 
 	list_for_each_safe(item, tmp, &e->head) {
 		struct simple_track *track = to_simple_track(item);
-		if (track->info == old) {
+		if (track->info == *old) {
 			if (new) {
 				track_info_unref(old);
 				track_info_ref(new);

--- a/editable.h
+++ b/editable.h
@@ -62,7 +62,7 @@ int _editable_for_each_sel(struct editable *e, int (*cb)(void *data, struct trac
 		void *data, int reverse);
 int editable_for_each_sel(struct editable *e, int (*cb)(void *data, struct track_info *ti),
 		void *data, int reverse);
-void editable_update_track(struct editable *e, struct track_info *old, struct track_info *new);
+void editable_update_track(struct editable *e, struct track_info **old, struct track_info *new);
 
 static inline void editable_track_to_iter(struct editable *e, struct simple_track *track, struct iter *iter)
 {

--- a/expr.c
+++ b/expr.c
@@ -681,7 +681,7 @@ static char *expand_short_expr(const char *expr_short)
 			}
 			break;
 		case ST_IN_QUOTE_STR:
-			if (c == '"' && expr_short[i-1] != '\\') {
+			if (c == '"' && i > 0 && expr_short[i-1] != '\\') {
 				stack4_pop(&state_stack);
 			}
 			out[k++] = c;

--- a/http.c
+++ b/http.c
@@ -121,7 +121,9 @@ void http_free_uri(struct http_uri *u)
 {
 	free(u->uri);
 	free(u->user);
-	free(u->pass);
+	if (u->pass) {
+		free(u->pass);
+	}
 	free(u->host);
 	free(u->path);
 

--- a/http.c
+++ b/http.c
@@ -513,6 +513,6 @@ char *base64_encode(const char *str)
 	case 0:
 		break;
 	}
-	buf[d++] = 0;
+	buf[d] = 0;
 	return buf;
 }

--- a/id3.c
+++ b/id3.c
@@ -729,8 +729,10 @@ static void decode_normal(struct id3tag *id3, const char *buf, int len, int enco
 		 * This must be TPE2 frame; ignore it if ID3_ALBUMARTIST is
 		 * already present
 		 */
-		if (id3->v2[key])
+		if (id3->v2[key]) {
+			free(out);
 			return;
+		}
 	} else if (key == ID3_PUBLISHER) {
 		 add_v2(id3, ID3_LABEL, strdup(out));
 	}

--- a/job.c
+++ b/job.c
@@ -331,7 +331,7 @@ void do_update_job(void *data)
 
 	for (i = 0; i < d->used; i++) {
 		struct track_info *ti = d->ti[i];
-		struct stat s;
+		struct stat s = {};
 		int rc;
 
 		/* stat follows symlinks, lstat does not */

--- a/job.c
+++ b/job.c
@@ -57,7 +57,7 @@ static void flush_ti_buffer(void)
 	editable_lock();
 	for (i = 0; i < ti_buffer_fill; i++) {
 		jd->add(ti_buffer[i]);
-		track_info_unref(ti_buffer[i]);
+		track_info_unref(&ti_buffer[i]);
 	}
 	editable_unlock();
 	ti_buffer_fill = 0;
@@ -354,7 +354,7 @@ void do_update_job(void *data)
 				cmus_add(lib_add_track, ti->filename, FILE_TYPE_FILE, JOB_TYPE_LIB, force);
 			}
 		}
-		track_info_unref(ti);
+		track_info_unref(&ti);
 	}
 }
 
@@ -386,16 +386,17 @@ void do_update_cache_job(void *data)
 		new = old->next;
 		if (lib_remove(old) && new)
 			lib_add_track(new);
-		editable_update_track(&pl_editable, old, new);
-		editable_update_track(&pq_editable, old, new);
+		editable_update_track(&pl_editable, &old, new);
+		if (old)
+			editable_update_track(&pq_editable, &old, new);
 		if (player_info.ti == old && new) {
 			track_info_ref(new);
 			player_file_changed(new);
 		}
 
-		track_info_unref(old);
+		track_info_unref(&old);
 		if (new)
-			track_info_unref(new);
+			track_info_unref(&new);
 	}
 	player_info_unlock();
 	editable_unlock();

--- a/lib.c
+++ b/lib.c
@@ -137,7 +137,7 @@ static void hash_remove(struct track_info *ti)
 		BUG_ON(e == NULL);
 		if (strcmp(e->ti->filename, filename) == 0) {
 			*entryp = e->next;
-			track_info_unref(e->ti);
+			track_info_unref(&e->ti);
 			free(e);
 			break;
 		}
@@ -316,7 +316,7 @@ static void free_lib_track(struct list_head *item)
 	rb_erase(&track->shuffle_track.tree_node, &lib_shuffle_root);
 	tree_remove(track);
 
-	track_info_unref(ti);
+	track_info_unref(&ti);
 	free(track);
 }
 
@@ -433,7 +433,7 @@ struct tree_track *lib_find_track(struct track_info *ti)
 void lib_store_cur_track(struct track_info *ti)
 {
 	if (cur_track_ti)
-		track_info_unref(cur_track_ti);
+		track_info_unref(&cur_track_ti);
 	cur_track_ti = ti;
 	track_info_ref(cur_track_ti);
 }
@@ -543,7 +543,7 @@ static void restore_sel_track(void)
 		struct tree_track *tt = lib_find_track(sel_track_ti);
 		if (tt) {
 			set_sel_track(tt);
-			track_info_unref(sel_track_ti);
+			track_info_unref(&sel_track_ti);
 			sel_track_ti = NULL;
 		}
 	}
@@ -623,7 +623,7 @@ void lib_clear_store(void)
 		e = ti_hash[i];
 		while (e) {
 			next = e->next;
-			track_info_unref(e->ti);
+			track_info_unref(&e->ti);
 			free(e);
 			e = next;
 		}

--- a/main.c
+++ b/main.c
@@ -349,8 +349,10 @@ int main(int argc, char *argv[])
 	if (server == NULL)
 		server = xstrdup(cmus_socket_path);
 
-	if (!remote_connect(server))
+	if (!remote_connect(server)){
+		free(server);
 		return 1;
+	}
 
 	if (raw_args) {
 		while (*argv)

--- a/main.c
+++ b/main.c
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2008-2013 Various Authors
  * Copyright 2005-2006 Timo Hirvonen
@@ -390,7 +391,7 @@ int main(int argc, char *argv[])
 		send_cmd("player-play\n");
 	if (flags[FLAG_PAUSE])
 		send_cmd("player-pause\n");
-	if (flags[FLAG_FILE])
+	if (flags[FLAG_FILE] && play_file)
 		send_cmd("player-play %s\n", file_url_absolute(play_file));
 	if (volume)
 		send_cmd("vol %s\n", volume);

--- a/misc.c
+++ b/misc.c
@@ -230,8 +230,8 @@ int misc_init(void)
 			cmus_socket_path = xstrjoin(xdg_runtime_dir, "/cmus-socket");
 		}
 	}
-
-	free(xdg_runtime_dir);
+	if (xdg_runtime_dir)
+		free(xdg_runtime_dir);
 	return 0;
 }
 

--- a/options.c
+++ b/options.c
@@ -918,7 +918,7 @@ static void set_auto_expand_albums_follow_int(int value)
 
 static void set_auto_expand_albums_follow(unsigned int id, const char *buf)
 {
-	int tmp;
+	int tmp = 0;
 	parse_bool(buf, &tmp);
 	set_auto_expand_albums_follow_int(tmp);
 }
@@ -942,7 +942,7 @@ static void set_auto_expand_albums_search_int(int value)
 
 static void set_auto_expand_albums_search(unsigned int id, const char *buf)
 {
-	int tmp;
+	int tmp = 0;
 	parse_bool(buf, &tmp);
 	set_auto_expand_albums_search_int(tmp);
 }
@@ -966,7 +966,7 @@ static void set_auto_expand_albums_selcur_int(int value)
 
 static void set_auto_expand_albums_selcur(unsigned int id, const char *buf)
 {
-	int tmp;
+	int tmp = 0;
 	parse_bool(buf, &tmp);
 	set_auto_expand_albums_selcur_int(tmp);
 }
@@ -1001,7 +1001,7 @@ static void set_show_all_tracks_int(int value)
 
 static void set_show_all_tracks(unsigned int id, const char *buf)
 {
-	int tmp;
+	int tmp = 0;
 	parse_bool(buf, &tmp);
 	set_show_all_tracks_int(tmp);
 }

--- a/options.c
+++ b/options.c
@@ -385,7 +385,6 @@ static sort_key_t *parse_sort_keys(const char *value)
 	int size = 4;
 	int pos = 0;
 
-	size = 4;
 	keys = xnew(sort_key_t, size);
 
 	s = value;

--- a/options.c
+++ b/options.c
@@ -1654,20 +1654,24 @@ static int handle_resume_line(void *data, const char *line)
 	if (strcmp(cmd, "status") == 0) {
 		parse_enum(arg, 0, NR_PLAYER_STATUS, player_status_names, (int *) &resume->status);
 	} else if (strcmp(cmd, "file") == 0) {
-		free(resume->filename);
+		if (resume->filename)
+			free(resume->filename);
 		resume->filename = xstrdup(unescape(arg));
 	} else if (strcmp(cmd, "position") == 0) {
 		str_to_int(arg, &resume->position);
 	} else if (strcmp(cmd, "lib_file") == 0) {
-		free(resume->lib_filename);
+		if (resume->lib_filename)
+			free(resume->lib_filename);
 		resume->lib_filename = xstrdup(unescape(arg));
 	} else if (strcmp(cmd, "view") == 0) {
 		parse_enum(arg, 0, NR_VIEWS, view_names, &resume->view);
 	} else if (strcmp(cmd, "live-filter") == 0) {
-		free(resume->live_filter);
+		if (resume->live_filter)
+			free(resume->live_filter);
 		resume->live_filter = xstrdup(unescape(arg));
 	} else if (strcmp(cmd, "browser-dir") == 0) {
-		free(resume->browser_dir);
+		if (resume->browser_dir)
+			free(resume->browser_dir);
 		resume->browser_dir = xstrdup(unescape(arg));
 	}
 

--- a/options.c
+++ b/options.c
@@ -1698,13 +1698,13 @@ void resume_load(void)
 		if (ti) {
 			editable_lock();
 			lib_add_track(ti);
-			track_info_unref(ti);
+			track_info_unref(&ti);
 			lib_store_cur_track(ti);
-			track_info_unref(ti);
+			track_info_unref(&ti);
 			ti = lib_set_track(lib_find_track(ti));
 			if (ti) {
 				BUG_ON(ti != old);
-				track_info_unref(ti);
+				track_info_unref(&ti);
 				tree_sel_current(auto_expand_albums_follow);
 				sorted_sel_current();
 			}

--- a/pl.c
+++ b/pl.c
@@ -34,7 +34,7 @@ static void pl_free_track(struct list_head *item)
 		pl_cur_track = NULL;
 
 	rb_erase(&shuffle_track->tree_node, &pl_shuffle_root);
-	track_info_unref(track->info);
+	track_info_unref(&track->info);
 	free(track);
 }
 

--- a/play_queue.c
+++ b/play_queue.c
@@ -27,7 +27,7 @@ static void pq_free_track(struct list_head *item)
 {
 	struct simple_track *track = to_simple_track(item);
 
-	track_info_unref(track->info);
+	track_info_unref(&track->info);
 	free(track);
 }
 

--- a/player.c
+++ b/player.c
@@ -405,7 +405,7 @@ static inline int get_next(struct track_info **ti)
 static inline void _file_changed(struct track_info *ti)
 {
 	if (player_info.ti)
-		track_info_unref(player_info.ti);
+		track_info_unref(&player_info.ti);
 
 	player_info.ti = ti;
 	update_rg_scale();
@@ -639,7 +639,7 @@ static void _producer_play(void)
 			if (rc) {
 				player_ip_error(rc, "opening file `%s'", ti->filename);
 				ip_delete(ip);
-				track_info_unref(ti);
+				track_info_unref(&ti);
 				file_changed(NULL);
 			} else {
 				ip_setup(ip);
@@ -828,7 +828,7 @@ static void _consumer_handle_eof(void)
 			_producer_play();
 			if (producer_status == PS_UNLOADED) {
 				_consumer_stop();
-				track_info_unref(ti);
+				track_info_unref(&ti);
 				file_changed(NULL);
 			} else {
 				/* PS_PLAYING */

--- a/server.c
+++ b/server.c
@@ -155,7 +155,7 @@ static int cmd_format_print(struct client *client, char *arg)
 		return write_all(client->fd, "\n", strlen("\n"));
 	}
 
-	int args_idx, ac, i, ret;
+	int args_idx = 0, ac, i, ret;
 	char **args = NULL;
 
 	if (arg)

--- a/track_info.c
+++ b/track_info.c
@@ -29,19 +29,20 @@
 #include <string.h>
 #include <math.h>
 
-static void track_info_free(struct track_info *ti)
+static void track_info_free(struct track_info **ti)
 {
-	keyvals_free(ti->comments);
-	free(ti->filename);
-	free(ti->codec);
-	free(ti->codec_profile);
-	free(ti->collkey_artist);
-	free(ti->collkey_album);
-	free(ti->collkey_title);
-	free(ti->collkey_genre);
-	free(ti->collkey_comment);
-	free(ti->collkey_albumartist);
-	free(ti);
+	keyvals_free((*ti)->comments);
+	free((*ti)->filename);
+	free((*ti)->codec);
+	free((*ti)->codec_profile);
+	free((*ti)->collkey_artist);
+	free((*ti)->collkey_album);
+	free((*ti)->collkey_title);
+	free((*ti)->collkey_genre);
+	free((*ti)->collkey_comment);
+	free((*ti)->collkey_albumartist);
+	free(*ti);
+	*ti = NULL;
 }
 
 struct track_info *track_info_new(const char *filename)
@@ -109,12 +110,13 @@ void track_info_ref(struct track_info *ti)
 	ti->ref++;
 }
 
-void track_info_unref(struct track_info *ti)
+void track_info_unref(struct track_info **ti)
 {
-	BUG_ON(ti->ref < 1);
-	ti->ref--;
-	if (ti->ref == 0)
+	BUG_ON((*ti)->ref < 1);
+	(*ti)->ref--;
+	if ((*ti)->ref == 0) {
 		track_info_free(ti);
+	}
 }
 
 int track_info_has_tag(const struct track_info *ti)

--- a/track_info.h
+++ b/track_info.h
@@ -127,7 +127,7 @@ struct track_info *track_info_new(const char *filename);
 void track_info_set_comments(struct track_info *ti, struct keyval *comments);
 
 void track_info_ref(struct track_info *ti);
-void track_info_unref(struct track_info *ti);
+void track_info_unref(struct track_info **ti);
 
 /*
  * returns: 1 if @ti has any of the following tags: artist, album, title

--- a/u_collate.c
+++ b/u_collate.c
@@ -35,7 +35,7 @@ int u_strcoll(const char *str1, const char *str2)
 	if (using_utf8) {
 		result = strcoll(str1, str2);
 	} else {
-		char *str1_locale, *str2_locale;
+		char *str1_locale = NULL, *str2_locale = NULL;
 
 		convert(str1, -1, &str1_locale, -1, charset, "UTF-8");
 		convert(str2, -1, &str2_locale, -1, charset, "UTF-8");


### PR DESCRIPTION
This PR fix multiple kinds of:
  - NULL pointer freeing
  - missing variable initialization
  - buffer under-run
  - memory leak (missing free)
  - duplicate/useless assignment

I'm not particularly proud of af413d7 but I can't found a better way to know if he the `old` track was the last referenced, and if so, avoid calling editable_update_track then track_info_unref again on it :/

Any advice would be appreciated