### PR TITLE
adding a player-pause-no-resume command

### DIFF
--- a/Doc/cmus-remote.txt
+++ b/Doc/cmus-remote.txt
@@ -41,6 +41,9 @@ When *-C* is given all command line arguments are treated as raw commands.
 -u, --pause
 	Toggle pause.
 
+-U, --pause-playback
+	Pause when currently playing.
+
 -s, --stop
 	Stop playing.
 

--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -463,6 +463,9 @@ player-next (*b*)
 player-pause (*c*)
 	Toggle pause.
 
+player-pause-playback
+	Pause when currently playing.
+
 player-play [filename] (*x*)
 	Play the given track, or, if none is specified, [re]play the current
 	track from the beginning.

--- a/command_mode.c
+++ b/command_mode.c
@@ -1334,6 +1334,11 @@ static void cmd_p_pause(char *arg)
 	player_pause();
 }
 
+static void cmd_p_pause_playback(char *arg)
+{
+	player_pause_playback();
+}
+
 static void cmd_p_play(char *arg)
 {
 	if (arg) {
@@ -2622,6 +2627,7 @@ struct command commands[] = {
 	{ "mark",		cmd_mark,	0, 1, NULL,		  0, 0 },
 	{ "player-next",	cmd_p_next,	0, 0, NULL,		  0, 0 },
 	{ "player-pause",	cmd_p_pause,	0, 0, NULL,		  0, 0 },
+	{ "player-pause-playback",	cmd_p_pause_playback, 0, 0, NULL, 0, 0 },
 	{ "player-play",	cmd_p_play,	0, 1, expand_playable,	  0, 0 },
 	{ "player-prev",	cmd_p_prev,	0, 0, NULL,		  0, 0 },
 	{ "player-stop",	cmd_p_stop,	0, 0, NULL,		  0, 0 },

--- a/main.c
+++ b/main.c
@@ -177,6 +177,7 @@ enum flags {
 
 	FLAG_PLAY,
 	FLAG_PAUSE,
+	FLAG_PAUSE_PLAYBACK,
 	FLAG_STOP,
 	FLAG_NEXT,
 	FLAG_PREV,
@@ -204,6 +205,7 @@ static struct option options[NR_FLAGS + 1] = {
 
 	{ 'p', "play", 0 },
 	{ 'u', "pause", 0 },
+	{ 'U', "pause-playback", 0 },
 	{ 's', "stop", 0 },
 	{ 'n', "next", 0 },
 	{ 'r', "prev", 0 },
@@ -241,6 +243,7 @@ static const char *usage =
 "Cooked mode:\n"
 "  -p, --play           player-play\n"
 "  -u, --pause          player-pause\n"
+"  -U, --pause-playback player-pause-playback\n"
 "  -s, --stop           player-stop\n"
 "  -n, --next           player-next\n"
 "  -r, --prev           player-prev\n"
@@ -328,6 +331,7 @@ int main(int argc, char *argv[])
 			break;
 		case FLAG_PLAY:
 		case FLAG_PAUSE:
+		case FLAG_PAUSE_PLAYBACK:
 		case FLAG_STOP:
 		case FLAG_NEXT:
 		case FLAG_PREV:
@@ -388,6 +392,8 @@ int main(int argc, char *argv[])
 		send_cmd("player-play\n");
 	if (flags[FLAG_PAUSE])
 		send_cmd("player-pause\n");
+	if (flags[FLAG_PAUSE_PLAYBACK])
+		send_cmd("player-pause-playback\n");
 	if (flags[FLAG_FILE])
 		send_cmd("player-play %s\n", file_url_absolute(play_file));
 	if (volume)

--- a/player.c
+++ b/player.c
@@ -1143,6 +1143,12 @@ void player_pause(void)
 	player_unlock();
 }
 
+void player_pause_playback(void)
+{
+	if (consumer_status == CS_PLAYING)
+		player_pause();
+}
+
 void player_set_file(struct track_info *ti)
 {
 	player_lock();

--- a/player.h
+++ b/player.h
@@ -105,6 +105,7 @@ void player_file_changed(struct track_info *ti);
 void player_play(void);
 void player_stop(void);
 void player_pause(void);
+void player_pause_playback(void);
 void player_seek(double offset, int relative, int start_playing);
 void player_set_op(const char *name);
 void player_set_buffer_chunks(unsigned int nr_chunks);


### PR DESCRIPTION
which only pauses if playing, but does not resume when stopped/paused

implements #403 

I'll add a dedicated cmus-remote command and the relevant documentation once you think the implementation is ok and worth integrating.