### PR TITLE
issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!-- Please fill the following if you found an issue, delete if otherwise. -->
+
+Expected behaviour: 
+
+Actual behaviour: 
+
+# Information
+## System
+- Operating System: 
+- Distribution/environment: 
+- Architecture: 
+- Compiler: 
+
+## cmus
+- plugins (output of `cmus --plugins`)
+```
+paste terminal output here
+```
+- version (branch/tag/version `cmus --version`)


### PR DESCRIPTION
Hey!

Often, when a bug is submitted, we don't immediately get all the information needed. Sometimes something was simply forgot to add, such as the compiler, plugins or cmus version. But to prevent that, I thought it might be a good idea to create an issue template.

You can try it by creating a [new issue](https://github.com/jayay/cmus/issues/new) in my fork. I'm pretty sure it's not complete yet, so please tell me what's missing or add it yourself.

I hope this is useful and saves some time in future.

Cheers!