### PR TITLE
Make the seek command not start playing when the player was stopped.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,3 +65,5 @@ Boris Timofeev <mashin87@gmail.com>
 
 Yue Wang <yuleopen@gmail.com>
   CoreAudio plugin
+
+Google Inc.

--- a/command_mode.c
+++ b/command_mode.c
@@ -551,7 +551,7 @@ inside:
 	}
 
 	if (!*arg) {
-		player_seek(seek, relative, 1);
+		player_seek(seek, relative, 0);
 		return;
 	}
 err:


### PR DESCRIPTION
Seeking when the player is paused moves the position without
unpausing. This makes seeking when the player is stopped work in a
similar way.

Fixes #438 