### PR TITLE
Trivial fixes to man pages

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -766,7 +766,7 @@ auto_expand_albums_follow, auto_expand_albums_search, auto_expand_albums_selcur 
 	If enabled, cmus will always open an artist and select the album when
 	following the currently played track or performing actions such as "search"
 	or "go to current track". This option is tightly coupled to the
-	show_all_tracks option. Any "auto_expand_albums_* = false" implies
+	show_all_tracks option. Any "auto_expand_albums_\* = false" implies
 	"show_all_tracks = true".
 
 auto_reshuffle (true)
@@ -1029,9 +1029,9 @@ scroll_offset (2) [0-9999]
 	Minimal number of screen lines to keep above and below the cursor.
 
 show_all_tracks (true)
-	Display all tracks of the artist when the artist is selected in the tree 
-	view. This option is tightly coupled to the auto_expand_albums_* options.
-	"show_all_tracks = false" implies "auto_expand_albums_* = true".
+	Display all tracks of the artist when the artist is selected in the tree
+	view. This option is tightly coupled to the auto_expand_albums_\* options.
+	"show_all_tracks = false" implies "auto_expand_albums_\* = true".
 
 show_hidden (false)
 	Display hidden files in browser.

--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -19,7 +19,7 @@ can be controlled from the outside via *cmus-remote*(1).
 @h1 OPTIONS
 
 --listen ADDR
-	Listen to ADDR (UNIX socket) instead of `$CMUS_SOCKET` or 
+	Listen to ADDR (UNIX socket) instead of `$CMUS_SOCKET` or
 	`$XDG_RUNTIME_DIR/cmus-socket`.
 	ADDR is either a UNIX socket or host[:port].
 
@@ -1264,7 +1264,7 @@ dsp.coreaudio.sync_sample_rate
 dsp.jack.server_name
 	Connect to jackd with this name. Leave empty for default.
 
-dsp.jack.resampling_quality 
+dsp.jack.resampling_quality
 	Sets the quality of the re-sampling. 0 is low quality but fast, 1 is
 	medium quality, 2 (default) is high quality but more CPU intensiv. This
 	option is only available if cmus was compiled with libsamplerate


### PR DESCRIPTION
- Fix some highlighting that got out of control
- Trailing whitespace