### PR TITLE
mpris support

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -986,6 +986,11 @@ mouse (false)
 	NOTE: Mouse wheel scrolling can lag if cmus is compiled with
 	old version of Ncurses.
 
+mpris (true)
+	Enable MPRIS support.
+
+	NOTE: This flag has no effect if cmus was compiled without MPRIS support.
+
 output_plugin [roar, pulse, alsa, arts, oss, sndio, sun, coreaudio]
 	Name of output plugin.
 

--- a/Makefile
+++ b/Makefile
@@ -21,13 +21,15 @@ CFLAGS += -D_FILE_OFFSET_BITS=64
 FFMPEG_CFLAGS += $(shell pkg-config --cflags libswresample)
 FFMPEG_LIBS += $(shell pkg-config --libs libswresample)
 
-CMUS_LIBS = $(PTHREAD_LIBS) $(NCURSES_LIBS) $(ICONV_LIBS) $(DL_LIBS) $(DISCID_LIBS) $(CUE_LIBS) -lm $(COMPAT_LIBS)
+CMUS_LIBS = $(PTHREAD_LIBS) $(NCURSES_LIBS) $(ICONV_LIBS) $(DL_LIBS) $(DISCID_LIBS) \
+			$(CUE_LIBS) -lm $(COMPAT_LIBS) $(LIBSYSTEMD_LIBS)
 
 input.o main.o ui_curses.o pulse.lo: .version
 input.o main.o ui_curses.o pulse.lo: CFLAGS += -DVERSION=\"$(VERSION)\"
 main.o server.o: CFLAGS += -DDEFAULT_PORT=3000
 discid.o: CFLAGS += $(DISCID_CFLAGS)
 job.o cue_utils.o: CFLAGS += $(CUE_CFLAGS)
+mpris.o: CFLAGS += $(LIBSYSTEMD_CFLAGS)
 
 .version: Makefile
 	@test "`cat $@ 2> /dev/null`" = "$(VERSION)" && exit 0; \
@@ -46,6 +48,7 @@ cmus-y := \
 	window.o worker.o xstrjoin.o
 
 cmus-$(CONFIG_CUE) += cue_utils.o
+cmus-$(CONFIG_MPRIS) += mpris.o
 
 $(cmus-y): CFLAGS += $(PTHREAD_CFLAGS) $(NCURSES_CFLAGS) $(ICONV_CFLAGS) $(DL_CFLAGS)
 

--- a/configure
+++ b/configure
@@ -257,6 +257,12 @@ check_vorbis()
 	fi
 }
 
+check_libsystemd()
+{
+	pkg_config LIBSYSTEMD "libsystemd"
+	return $?
+}
+
 check_opus()
 {
 	pkg_config OPUS "opusfile"
@@ -493,6 +499,7 @@ Optional Features: y/n
   CONFIG_SNDIO    	Sndio                                           [auto]
   CONFIG_SUN      	Sun Audio                                       [auto]
   CONFIG_WAVEOUT  	Windows Wave Out                                [auto]
+  CONFIG_MPRIS  	MPRIS                                           [auto]
   USE_FALLBACK_IP	Use a specific IP for every unrecognized	[n]
                         input format. Currently set to FFMPEG.
 
@@ -531,37 +538,38 @@ check_header byteswap.h && HAVE_BYTESWAP_H=y
 check_string_function "strdup" && HAVE_STRDUP=y
 check_string_function "strndup" && HAVE_STRNDUP=y
 
-check check_cddb    CONFIG_CDDB
-check check_cdio    CONFIG_CDIO
-check check_flac    CONFIG_FLAC
-check check_mad     CONFIG_MAD
-check check_mikmod  CONFIG_MIKMOD
-check check_modplug CONFIG_MODPLUG
-check check_mpc     CONFIG_MPC
-check check_vorbis  CONFIG_VORBIS
-check check_opus    CONFIG_OPUS
-check check_wavpack CONFIG_WAVPACK
-check check_mp4     CONFIG_MP4
-check check_aac     CONFIG_AAC
-check check_ffmpeg  CONFIG_FFMPEG
-check check_cue     CONFIG_CUE
-check check_cue2    CONFIG_CUE2
-check check_vtx     CONFIG_VTX
+check check_cddb       CONFIG_CDDB
+check check_cdio       CONFIG_CDIO
+check check_flac       CONFIG_FLAC
+check check_mad        CONFIG_MAD
+check check_mikmod     CONFIG_MIKMOD
+check check_modplug    CONFIG_MODPLUG
+check check_mpc        CONFIG_MPC
+check check_vorbis     CONFIG_VORBIS
+check check_opus       CONFIG_OPUS
+check check_libsystemd CONFIG_MPRIS
+check check_wavpack    CONFIG_WAVPACK
+check check_mp4        CONFIG_MP4
+check check_aac        CONFIG_AAC
+check check_ffmpeg     CONFIG_FFMPEG
+check check_cue        CONFIG_CUE
+check check_cue2       CONFIG_CUE2
+check check_vtx        CONFIG_VTX
 # nothing to check, just validate the variable values
-check true          CONFIG_TREMOR
-check true          CONFIG_WAV
-check check_pulse   CONFIG_PULSE
-check check_alsa    CONFIG_ALSA
-check check_jack    CONFIG_JACK
+check true             CONFIG_TREMOR
+check true             CONFIG_WAV
+check check_pulse      CONFIG_PULSE
+check check_alsa       CONFIG_ALSA
+check check_jack       CONFIG_JACK
 check check_samplerate CONFIG_SAMPLERATE
-check check_ao      CONFIG_AO
-check check_coreaudio   CONFIG_COREAUDIO
-check check_arts    CONFIG_ARTS
-check check_oss     CONFIG_OSS
-check check_sndio   CONFIG_SNDIO
-check check_sun     CONFIG_SUN
-check check_waveout CONFIG_WAVEOUT
-check check_roar    CONFIG_ROAR
+check check_ao         CONFIG_AO
+check check_coreaudio  CONFIG_COREAUDIO
+check check_arts       CONFIG_ARTS
+check check_oss        CONFIG_OSS
+check check_sndio      CONFIG_SNDIO
+check check_sun        CONFIG_SUN
+check check_waveout    CONFIG_WAVEOUT
+check check_roar       CONFIG_ROAR
 
 # discid is only needed if at least one cdda plugin is active
 test -z "$CONFIG_DISCID" && CONFIG_DISCID=a
@@ -578,6 +586,7 @@ DATADIR="$datadir"
 LIBDIR="$libdir"
 
 config_header config/cdio.h HAVE_CDDB
+config_header config/mpris.h CONFIG_MPRIS
 config_header config/datadir.h DATADIR
 config_header config/libdir.h LIBDIR
 config_header config/debug.h DEBUG
@@ -597,6 +606,6 @@ CFLAGS="${CFLAGS} -DHAVE_CONFIG"
 
 makefile_vars bindir datadir libdir mandir exampledir
 makefile_vars CONFIG_CDIO CONFIG_FLAC CONFIG_MAD CONFIG_MIKMOD CONFIG_MODPLUG CONFIG_MPC CONFIG_VORBIS CONFIG_OPUS CONFIG_WAVPACK CONFIG_WAV CONFIG_MP4 CONFIG_AAC CONFIG_FFMPEG CONFIG_CUE CONFIG_CUE2 CONFIG_VTX
-makefile_vars CONFIG_ROAR CONFIG_PULSE CONFIG_ALSA CONFIG_JACK CONFIG_SAMPLERATE CONFIG_AO CONFIG_COREAUDIO CONFIG_ARTS CONFIG_OSS CONFIG_SNDIO CONFIG_SUN CONFIG_WAVEOUT
+makefile_vars CONFIG_ROAR CONFIG_PULSE CONFIG_ALSA CONFIG_JACK CONFIG_SAMPLERATE CONFIG_AO CONFIG_COREAUDIO CONFIG_ARTS CONFIG_OSS CONFIG_SNDIO CONFIG_SUN CONFIG_WAVEOUT CONFIG_MPRIS
 
 generate_config_mk

--- a/locking.c
+++ b/locking.c
@@ -34,3 +34,20 @@ void cmus_mutex_unlock(pthread_mutex_t *mutex)
 	if (unlikely(rc))
 		BUG("error unlocking mutex: %s\n", strerror(rc));
 }
+
+void cmus_mutex_init_recursive(pthread_mutex_t *mutex)
+{
+	pthread_mutexattr_t attr;
+	int rc = pthread_mutexattr_init(&attr);
+	if (rc)
+		goto err;
+	rc = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+	if (rc)
+		goto err;
+	rc = pthread_mutex_init(mutex, &attr);
+	if (rc)
+		goto err;
+	return;
+err:
+	BUG("error initializing recursive mutex: %s\n", strerror(rc));
+}

--- a/locking.h
+++ b/locking.h
@@ -26,5 +26,6 @@
 
 void cmus_mutex_lock(pthread_mutex_t *mutex);
 void cmus_mutex_unlock(pthread_mutex_t *mutex);
+void cmus_mutex_init_recursive(pthread_mutex_t *mutex);
 
 #endif

--- a/mpris.c
+++ b/mpris.c
@@ -1,0 +1,558 @@
+/*
+ * Copyright 2016 Various Authors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <systemd/sd-bus.h>
+
+#include "mpris.h"
+#include "ui_curses.h"
+#include "cmus.h"
+#include "player.h"
+#include "options.h"
+#include "output.h"
+#include "track_info.h"
+#include "utils.h"
+
+#define CK(v) \
+do { \
+	int tmp = (v); \
+	if (tmp < 0) \
+		return tmp; \
+} while (0)
+
+static sd_bus *bus;
+int mpris_fd = -1;
+
+static struct track_info *mpris_get_ti(void)
+{
+	player_info_lock();
+	struct track_info *ti = player_info.ti;
+	if (ti)
+		track_info_ref(ti);
+	player_info_unlock();
+	return ti;
+}
+
+static int mpris_msg_ignore(sd_bus_message *m, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	return sd_bus_reply_method_return(m, "");
+}
+
+static int mpris_read_false(sd_bus *_bus, const char *_path,
+		const char *_interface, const char *_property,
+		sd_bus_message *reply, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	uint32_t b = 0;
+	return sd_bus_message_append_basic(reply, 'b', &b);
+}
+
+static int mpris_read_true(sd_bus *_bus, const char *_path,
+		const char *_interface, const char *_property,
+		sd_bus_message *reply, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	uint32_t b = 1;
+	return sd_bus_message_append_basic(reply, 'b', &b);
+}
+
+static int mpris_write_ignore(sd_bus *_bus, const char *_path,
+		const char *_interface, const char *_property,
+		sd_bus_message *value, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	return sd_bus_reply_method_return(value, "");
+}
+
+static int mpris_identity(sd_bus *_bus, const char *_path,
+		const char *_interface, const char *_property,
+		sd_bus_message *reply, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	const char *id = "cmus";
+	return sd_bus_message_append_basic(reply, 's', id);
+}
+
+static int mpris_uri_schemes(sd_bus *_bus, const char *_path,
+		const char *_interface, const char *_property,
+		sd_bus_message *reply, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	static const char * const schemes[] = { "file", "http", NULL };
+	return sd_bus_message_append_strv(reply, (char **)schemes);
+}
+
+static int mpris_mime_types(sd_bus *_bus, const char *_path,
+		const char *_interface, const char *_property,
+		sd_bus_message *reply, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	static const char * const types[] = { NULL };
+	return sd_bus_message_append_strv(reply, (char **)types);
+}
+
+static int mpris_next(sd_bus_message *m, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	cmus_next();
+	return sd_bus_reply_method_return(m, "");
+}
+
+static int mpris_prev(sd_bus_message *m, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	cmus_prev();
+	return sd_bus_reply_method_return(m, "");
+}
+
+static int mpris_pause(sd_bus_message *m, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	player_pause_playback();
+	return sd_bus_reply_method_return(m, "");
+}
+
+static int mpris_toggle_pause(sd_bus_message *m, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	player_pause();
+	return sd_bus_reply_method_return(m, "");
+}
+
+static int mpris_stop(sd_bus_message *m, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	player_stop();
+	return sd_bus_reply_method_return(m, "");
+}
+
+static int mpris_play(sd_bus_message *m, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	player_play();
+	return sd_bus_reply_method_return(m, "");
+}
+
+static int mpris_seek(sd_bus_message *m, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	int64_t val = 0;
+	CK(sd_bus_message_read_basic(m, 'x', &val));
+	player_seek(val / (1000 * 1000), 1, 0);
+	return sd_bus_reply_method_return(m, "");
+}
+
+static int mpris_seek_abs(sd_bus_message *m, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	CLEANUP(track_info_unrefp) struct track_info *ti = mpris_get_ti();
+	char buf[] = "/1122334455667788";
+	if (ti)
+		sprintf(buf, "/%"PRIx64, ti->uid);
+	else
+		sprintf(buf, "/");
+
+	const char *path = NULL;
+	int64_t val = 0;
+	CK(sd_bus_message_read_basic(m, 'o', &path));
+	CK(sd_bus_message_read_basic(m, 'x', &val));
+
+	if (strcmp(buf, path) == 0)
+		player_seek(val / (1000 * 1000), 0, 0);
+	return sd_bus_reply_method_return(m, "");
+}
+
+static int mpris_play_file(sd_bus_message *m, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	const char *path = NULL;
+	CK(sd_bus_message_read_basic(m, 's', &path));
+	cmus_play_file(path);
+	return sd_bus_reply_method_return(m, "");
+}
+
+static int mpris_playback_status(sd_bus *_bus, const char *_path,
+		const char *_interface, const char *_property,
+		sd_bus_message *reply, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	const char *ss[] = { "Stopped", "Playing", "Paused" };
+	player_info_lock();
+	const char *s = ss[player_info.status];
+	player_info_unlock();
+	return sd_bus_message_append_basic(reply, 's', s);
+}
+
+static int mpris_loop_status(sd_bus *_bus, const char *_path,
+		const char *_interface, const char *_property,
+		sd_bus_message *reply, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	const char *t = "None";
+	if (player_repeat_current)
+		t = "Track";
+	else if (repeat)
+		t = "Playlist";
+	return sd_bus_message_append_basic(reply, 's', t);
+}
+
+static int mpris_set_loop_status(sd_bus *_bus, const char *_path,
+		const char *_interface, const char *_property,
+		sd_bus_message *value, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	const char *t = NULL;
+	CK(sd_bus_message_read_basic(value, 's', &t));
+	if (strcmp(t, "None") == 0) {
+		player_repeat_current = 0;
+		repeat = 0;
+	} else if (strcmp(t, "Track") == 0) {
+		player_repeat_current = 1;
+	} else if (strcmp(t, "Playlist") == 0) {
+		player_repeat_current = 0;
+		repeat = 1;
+	}
+	update_statusline();
+	return sd_bus_reply_method_return(value, "");
+}
+
+static int mpris_rate(sd_bus *_bus, const char *_path,
+		const char *_interface, const char *_property,
+		sd_bus_message *reply, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	static const double d = 1.0;
+	return sd_bus_message_append_basic(reply, 'd', &d);
+}
+
+static int mpris_shuffle(sd_bus *_bus, const char *_path,
+		const char *_interface, const char *_property,
+		sd_bus_message *reply, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	const uint32_t s = shuffle;
+	return sd_bus_message_append_basic(reply, 'b', &s);
+}
+
+static int mpris_set_shuffle(sd_bus *_bus, const char *_path,
+		const char *_interface, const char *_property,
+		sd_bus_message *value, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	uint32_t s = 0;
+	CK(sd_bus_message_read_basic(value, 'b', &s));
+	shuffle = s;
+	update_statusline();
+	return sd_bus_reply_method_return(value, "");
+}
+
+static int mpris_volume(sd_bus *_bus, const char *_path,
+		const char *_interface, const char *_property,
+		sd_bus_message *reply, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	double vol;
+	if (soft_vol) {
+		vol = (soft_vol_l + soft_vol_r) / 200.0;
+	} else if (volume_max && volume_l >= 0 && volume_r >= 0) {
+		int vol_left = scale_to_percentage(volume_l, volume_max);
+		int vol_right = scale_to_percentage(volume_r, volume_max);
+		vol = (vol_left + vol_right) / 200.0;
+	}
+	return sd_bus_message_append_basic(reply, 'd', &vol);
+}
+
+static int mpris_set_volume(sd_bus *_bus, const char *_path,
+		const char *_interface, const char *_property,
+		sd_bus_message *value, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	double vol;
+	CK(sd_bus_message_read_basic(value, 'd', &vol));
+	if (vol < 0.0)
+		vol = 0.0;
+	else if (vol > 1.0)
+		vol = 1.0;
+	int ivol = vol * 100;
+	player_set_vol(ivol, VF_PERCENTAGE, ivol, VF_PERCENTAGE);
+	update_statusline();
+	return sd_bus_reply_method_return(value, "");
+}
+
+static int mpris_position(sd_bus *_bus, const char *_path,
+		const char *_interface, const char *_property,
+		sd_bus_message *reply, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	player_info_lock();
+	int64_t pos = player_info.pos;
+	player_info_unlock();
+	pos *= 1000 * 1000;
+	return sd_bus_message_append_basic(reply, 'x', &pos);
+}
+
+static int mpris_msg_append_simple_dict(sd_bus_message *m, const char *tag,
+		char type, const void *val)
+{
+	const char s[] = { type, 0 };
+	CK(sd_bus_message_open_container(m, 'e', "sv"));
+	CK(sd_bus_message_append_basic(m, 's', tag));
+	CK(sd_bus_message_open_container(m, 'v', s));
+	CK(sd_bus_message_append_basic(m, type, val));
+	CK(sd_bus_message_close_container(m));
+	CK(sd_bus_message_close_container(m));
+	return 0;
+}
+
+static int mpris_msg_append_si_dict(sd_bus_message *m, const char *a,
+		int32_t i)
+{
+	return mpris_msg_append_simple_dict(m, a, 'i', &i);
+}
+
+static int mpris_msg_append_sx_dict(sd_bus_message *m, const char *a,
+		int64_t i)
+{
+	return mpris_msg_append_simple_dict(m, a, 'x', &i);
+}
+
+static int mpris_msg_append_ss_dict(sd_bus_message *m, const char *a,
+		const char *b)
+{
+	return mpris_msg_append_simple_dict(m, a, 's', b);
+}
+
+static int mpris_msg_append_so_dict(sd_bus_message *m, const char *a,
+		const char *b)
+{
+	return mpris_msg_append_simple_dict(m, a, 'o', b);
+}
+
+static int mpris_msg_append_sas_dict(sd_bus_message *m, const char *a,
+		const char *b)
+{
+	CK(sd_bus_message_open_container(m, 'e', "sv"));
+	CK(sd_bus_message_append_basic(m, 's', a));
+	CK(sd_bus_message_open_container(m, 'v', "as"));
+	CK(sd_bus_message_open_container(m, 'a', "s"));
+	CK(sd_bus_message_append_basic(m, 's', b));
+	CK(sd_bus_message_close_container(m));
+	CK(sd_bus_message_close_container(m));
+	CK(sd_bus_message_close_container(m));
+	return 0;
+}
+
+static int mpris_metadata(sd_bus *_bus, const char *_path,
+		const char *_interface, const char *_property,
+		sd_bus_message *reply, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	CK(sd_bus_message_open_container(reply, 'a', "{sv}"));
+
+	CLEANUP(track_info_unrefp) struct track_info *ti = mpris_get_ti();
+	if (ti) {
+		char buf[] = "/1122334455667788";
+		sprintf(buf, "/%"PRIx64, ti->uid);
+		CK(mpris_msg_append_so_dict(reply, "mpris:trackid", buf));
+
+		int64_t dur = ti->duration;
+		dur *= 1000 * 1000;
+		CK(mpris_msg_append_sx_dict(reply, "mpris:length", dur));
+
+		if (ti->artist)
+			CK(mpris_msg_append_sas_dict(reply, "xesam:artist",
+						ti->artist));
+		if (ti->title)
+			CK(mpris_msg_append_ss_dict(reply, "xesam:title",
+						ti->title));
+		if (ti->album)
+			CK(mpris_msg_append_ss_dict(reply, "xesam:album",
+						ti->album));
+		if (ti->albumartist)
+			CK(mpris_msg_append_sas_dict(reply, "xesam:albumArtist",
+						ti->albumartist));
+		if (ti->genre)
+			CK(mpris_msg_append_sas_dict(reply, "xesam:genre",
+						ti->genre));
+		if (ti->comment)
+			CK(mpris_msg_append_sas_dict(reply, "xesam:comment",
+						ti->comment));
+		if (ti->bpm != -1)
+			CK(mpris_msg_append_si_dict(reply, "xesam:audioBPM",
+						ti->bpm));
+		if (ti->tracknumber != -1)
+			CK(mpris_msg_append_si_dict(reply, "xesam:trackNumber",
+						ti->tracknumber));
+		if (ti->discnumber != -1)
+			CK(mpris_msg_append_si_dict(reply, "xesam:discNumber",
+						ti->discnumber));
+	}
+
+	CK(sd_bus_message_close_container(reply));
+	return 0;
+}
+
+#define MPRIS_PROP(name, type, read) \
+	SD_BUS_PROPERTY(name, type, read, 0, \
+			SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE)
+
+#define MPRIS_WPROP(name, type, read, write) \
+	SD_BUS_WRITABLE_PROPERTY(name, type, read, write, 0, \
+			SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE)
+
+static const sd_bus_vtable media_player2_vt[] = {
+	SD_BUS_VTABLE_START(0),
+	SD_BUS_METHOD("Raise", "", "", mpris_msg_ignore, 0),
+	SD_BUS_METHOD("Quit", "", "", mpris_msg_ignore, 0),
+	MPRIS_PROP("CanQuit", "b", mpris_read_false),
+	MPRIS_WPROP("Fullscreen", "b", mpris_read_false, mpris_write_ignore),
+	MPRIS_PROP("CanSetFullscreen", "b", mpris_read_false),
+	MPRIS_PROP("CanRaise", "b", mpris_read_false),
+	MPRIS_PROP("HasTrackList", "b", mpris_read_false),
+	MPRIS_PROP("Identity", "s", mpris_identity),
+	MPRIS_PROP("SupportedUriSchemes", "as", mpris_uri_schemes),
+	MPRIS_PROP("SupportedMimeTypes", "as", mpris_mime_types),
+	SD_BUS_VTABLE_END,
+};
+
+static const sd_bus_vtable media_player2_player_vt[] = {
+	SD_BUS_VTABLE_START(0),
+	SD_BUS_METHOD("Next", "", "", mpris_next, 0),
+	SD_BUS_METHOD("Previous", "", "", mpris_prev, 0),
+	SD_BUS_METHOD("Pause", "", "", mpris_pause, 0),
+	SD_BUS_METHOD("PlayPause", "", "", mpris_toggle_pause, 0),
+	SD_BUS_METHOD("Stop", "", "", mpris_stop, 0),
+	SD_BUS_METHOD("Play", "", "", mpris_play, 0),
+	SD_BUS_METHOD("Seek", "x", "", mpris_seek, 0),
+	SD_BUS_METHOD("SetPosition", "ox", "", mpris_seek_abs, 0),
+	SD_BUS_METHOD("OpenUri", "s", "", mpris_play_file, 0),
+	MPRIS_PROP("PlaybackStatus", "s", mpris_playback_status),
+	MPRIS_WPROP("LoopStatus", "s", mpris_loop_status, mpris_set_loop_status),
+	MPRIS_WPROP("Rate", "d", mpris_rate, mpris_write_ignore),
+	MPRIS_WPROP("Shuffle", "b", mpris_shuffle, mpris_set_shuffle),
+	MPRIS_WPROP("Volume", "d", mpris_volume, mpris_set_volume),
+	SD_BUS_PROPERTY("Position", "x", mpris_position, 0, 0),
+	MPRIS_PROP("MinimumRate", "d", mpris_rate),
+	MPRIS_PROP("MaximumRate", "d", mpris_rate),
+	MPRIS_PROP("CanGoNext", "b", mpris_read_true),
+	MPRIS_PROP("CanGoPrev", "b", mpris_read_true),
+	MPRIS_PROP("CanPlay", "b", mpris_read_true),
+	MPRIS_PROP("CanPause", "b", mpris_read_true),
+	MPRIS_PROP("CanSeek", "b", mpris_read_true),
+	SD_BUS_PROPERTY("CanControl", "b", mpris_read_true, 0, 0),
+	MPRIS_PROP("Metadata", "a{sv}", mpris_metadata),
+	SD_BUS_SIGNAL("Seeked", "x", 0),
+	SD_BUS_VTABLE_END,
+};
+
+void mpris_init(void)
+{
+	int res = 0;
+
+	res = sd_bus_default_user(&bus);
+	if (res < 0)
+		goto out;
+	res = sd_bus_add_object_vtable(bus, NULL, "/org/mpris/MediaPlayer2",
+			"org.mpris.MediaPlayer2", media_player2_vt, NULL);
+	if (res < 0)
+		goto out;
+	res = sd_bus_add_object_vtable(bus, NULL, "/org/mpris/MediaPlayer2",
+			"org.mpris.MediaPlayer2.Player",
+			media_player2_player_vt, NULL);
+	if (res < 0)
+		goto out;
+	res = sd_bus_request_name(bus, "org.mpris.MediaPlayer2.cmus", 0);
+	mpris_fd = sd_bus_get_fd(bus);
+
+out:
+	if (res < 0) {
+		sd_bus_unref(bus);
+		bus = NULL;
+		mpris_fd = -1;
+
+		const char *msg = "an error occured while initializing "
+			          "MPRIS: %s. MPRIS will be disabled.";
+
+		error_msg(msg, strerror(-res));
+	}
+}
+
+void mpris_process(void)
+{
+	if (bus) {
+		while (sd_bus_process(bus, NULL) > 0)
+			;
+	}
+}
+
+void mpris_free(void)
+{
+	sd_bus_unref(bus);
+	bus = NULL;
+	mpris_fd = -1;
+}
+
+static void mpris_player_property_changed(const char *name)
+{
+	const char * const strv[] = { name, NULL };
+	if (bus) {
+		sd_bus_emit_properties_changed_strv(bus,
+				"/org/mpris/MediaPlayer2",
+				"org.mpris.MediaPlayer2.Player", (char **)strv);
+		sd_bus_flush(bus);
+	}
+}
+
+void mpris_playback_status_changed(void)
+{
+	mpris_player_property_changed("PlaybackStatus");
+}
+
+void mpris_loop_status_changed(void)
+{
+	mpris_player_property_changed("LoopStatus");
+}
+
+void mpris_shuffle_changed(void)
+{
+	mpris_player_property_changed("Shuffle");
+}
+
+void mpris_volume_changed(void)
+{
+	mpris_player_property_changed("Volume");
+}
+
+void mpris_metadata_changed(void)
+{
+	mpris_player_property_changed("Metadata");
+	// the following is not necessary according to the spec but some
+	// applications seem to disregard the spec and expect this to happen
+	mpris_seeked();
+}
+
+void mpris_seeked(void)
+{
+	if (!bus)
+		return;
+	player_info_lock();
+	int64_t pos = player_info.pos;
+	player_info_unlock();
+	pos *= 1000 * 1000;
+	sd_bus_emit_signal(bus, "/org/mpris/MediaPlayer2",
+			"org.mpris.MediaPlayer2.Player", "Seeked", "x", pos);
+}

--- a/mpris.h
+++ b/mpris.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2008-2013 Various Authors
+ * Copyright 2004 Timo Hirvonen
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CMUS_MPRIS_H
+#define CMUS_MPRIS_H
+
+#include "config/mpris.h"
+
+#ifdef CONFIG_MPRIS
+
+extern int mpris_fd;
+void mpris_init(void);
+void mpris_process(void);
+void mpris_free(void);
+void mpris_playback_status_changed(void);
+void mpris_loop_status_changed(void);
+void mpris_shuffle_changed(void);
+void mpris_volume_changed(void);
+void mpris_metadata_changed(void);
+void mpris_seeked(void);
+
+#else
+
+__attribute__((unused)) static int mpris_fd = -1;
+__attribute__((unused)) static void mpris_init(void) { }
+__attribute__((unused)) static void mpris_process(void) { }
+__attribute__((unused)) static void mpris_free(void) { }
+__attribute__((unused)) static void mpris_playback_status_changed(void) { }
+__attribute__((unused)) static void mpris_loop_status_changed(void) { }
+__attribute__((unused)) static void mpris_shuffle_changed(void) { }
+__attribute__((unused)) static void mpris_volume_changed(void) { }
+__attribute__((unused)) static void mpris_metadata_changed(void) { }
+__attribute__((unused)) static void mpris_seeked(void) { }
+
+#endif
+
+#endif

--- a/mpris.h
+++ b/mpris.h
@@ -36,16 +36,16 @@ void mpris_seeked(void);
 
 #else
 
-__attribute__((unused)) static int mpris_fd = -1;
-__attribute__((unused)) static void mpris_init(void) { }
-__attribute__((unused)) static void mpris_process(void) { }
-__attribute__((unused)) static void mpris_free(void) { }
-__attribute__((unused)) static void mpris_playback_status_changed(void) { }
-__attribute__((unused)) static void mpris_loop_status_changed(void) { }
-__attribute__((unused)) static void mpris_shuffle_changed(void) { }
-__attribute__((unused)) static void mpris_volume_changed(void) { }
-__attribute__((unused)) static void mpris_metadata_changed(void) { }
-__attribute__((unused)) static void mpris_seeked(void) { }
+#define mpris_fd -1
+#define mpris_init() { }
+#define mpris_process() { }
+#define mpris_free() { }
+#define mpris_playback_status_changed() { }
+#define mpris_loop_status_changed() { }
+#define mpris_shuffle_changed() { }
+#define mpris_volume_changed() { }
+#define mpris_metadata_changed() { }
+#define mpris_seeked() { }
 
 #endif
 

--- a/options.h
+++ b/options.h
@@ -142,6 +142,7 @@ extern int scroll_offset;
 extern int rewind_offset;
 extern int skip_track_info;
 extern int mouse;
+extern int mpris;
 
 extern const char * const aaa_mode_names[];
 extern const char * const view_names[NR_VIEWS + 1];

--- a/player.c
+++ b/player.c
@@ -1020,6 +1020,12 @@ void player_init(const struct player_callbacks *callbacks)
 #endif
 	pthread_attr_t *attrp = NULL;
 
+	/* This mutex is locked inside of the mpris implementation which is
+	 * called into from many different places. It is not trivial to see if
+	 * those places do already hold this lock and so the mpris functions
+	 * always acquires it. To avoid deadlocks in the places where the lock
+	 * is already held by the calling context, we use a recursive mutex.
+	 */
 	cmus_mutex_init_recursive(&player_info.mutex);
 
 	/*  1 s is 176400 B (0.168 MB)

--- a/player.h
+++ b/player.h
@@ -117,6 +117,10 @@ void player_set_rg(enum replaygain rg);
 void player_set_rg_limit(int limit);
 void player_set_rg_preamp(double db);
 
+#define VF_RELATIVE	0x01
+#define VF_PERCENTAGE	0x02
+int player_set_vol(int l, int lf, int r, int rf);
+
 #define player_info_lock() cmus_mutex_lock(&player_info.mutex)
 #define player_info_unlock() cmus_mutex_unlock(&player_info.mutex)
 

--- a/track_info.c
+++ b/track_info.c
@@ -46,8 +46,12 @@ static void track_info_free(struct track_info *ti)
 
 struct track_info *track_info_new(const char *filename)
 {
+	static uint64_t cur_uid = 0;
+	cur_uid++;
+
 	struct track_info *ti;
 	ti = xnew(struct track_info, 1);
+	ti->uid = cur_uid;
 	ti->filename = xstrdup(filename);
 	ti->ref = 1;
 	ti->play_count = 0;
@@ -115,6 +119,13 @@ void track_info_unref(struct track_info *ti)
 	ti->ref--;
 	if (ti->ref == 0)
 		track_info_free(ti);
+}
+
+void track_info_unrefp(struct track_info **ti)
+{
+	if (*ti)
+		track_info_unref(*ti);
+	*ti = NULL;
 }
 
 int track_info_has_tag(const struct track_info *ti)

--- a/track_info.h
+++ b/track_info.h
@@ -21,8 +21,10 @@
 
 #include <time.h>
 #include <stddef.h>
+#include <stdint.h>
 
 struct track_info {
+	uint64_t uid;
 	struct keyval *comments;
 
 	// next track_info in the hash table (cache.c)
@@ -128,6 +130,7 @@ void track_info_set_comments(struct track_info *ti, struct keyval *comments);
 
 void track_info_ref(struct track_info *ti);
 void track_info_unref(struct track_info *ti);
+void track_info_unrefp(struct track_info **ti);
 
 /*
  * returns: 1 if @ti has any of the following tags: artist, album, title

--- a/utils.h
+++ b/utils.h
@@ -53,6 +53,7 @@
 #define STATIC_ASSERT(cond) \
 	static uint8_t CONCATENATE(_cmus_unused_, __LINE__)[2*(cond) - 1] UNUSED
 
+#define CLEANUP(f) __attribute__((cleanup(f)))
 
 static inline int min(int a, int b)
 {


### PR DESCRIPTION
At long last this PR continues the work started in #90. Thanks to the new sd-bus API it's now much easier to implement MPRIS support in plain C. This allows cmus to integrate with various desktop environments. See the screenshot below. Some minor changes had to be made to the existing code but nothing major. The `track_info` structure now has a `uid` field which is a unique integer and allows each track to be identified by MPRIS clients. Not every feature is implemented. For example, the CanGoNext property always returns true even if there is no next track to play. Implementing this properly would require more refactoring. This can be done in the future.

![screenshot from 2016-06-22 16-40-06](https://cloud.githubusercontent.com/assets/1882250/16271346/e63750be-3899-11e6-889c-bacd15bdf5c4.png)
