### PR TITLE
use a void ptr instead of an unsigned for option multiplexing

### DIFF
--- a/aac.c
+++ b/aac.c
@@ -534,4 +534,4 @@ const struct input_plugin_ops ip_ops = {
 const int ip_priority = 50;
 const char * const ip_extensions[] = { "aac", NULL };
 const char * const ip_mime_types[] = { "audio/aac", "audio/aacp", NULL };
-const char * const ip_options[] = { NULL };
+const struct input_plugin_opt ip_options[] = { { NULL } };

--- a/alsa.c
+++ b/alsa.c
@@ -345,29 +345,17 @@ static int op_alsa_unpause(void)
 	return alsa_error_to_op_error(rc);
 }
 
-static int op_alsa_set_option(int key, const char *val)
+static int op_alsa_set_device(const char *val)
 {
-	switch (key) {
-	case 0:
-		free(alsa_dsp_device);
-		alsa_dsp_device = xstrdup(val);
-		break;
-	default:
-		return -OP_ERROR_NOT_OPTION;
-	}
+	free(alsa_dsp_device);
+	alsa_dsp_device = xstrdup(val);
 	return OP_ERROR_SUCCESS;
 }
 
-static int op_alsa_get_option(int key, char **val)
+static int op_alsa_get_device(char **val)
 {
-	switch (key) {
-	case 0:
-		if (alsa_dsp_device)
-			*val = xstrdup(alsa_dsp_device);
-		break;
-	default:
-		return -OP_ERROR_NOT_OPTION;
-	}
+	if (alsa_dsp_device)
+		*val = xstrdup(alsa_dsp_device);
 	return OP_ERROR_SUCCESS;
 }
 
@@ -381,13 +369,11 @@ const struct output_plugin_ops op_pcm_ops = {
 	.buffer_space = op_alsa_buffer_space,
 	.pause = op_alsa_pause,
 	.unpause = op_alsa_unpause,
-	.set_option = op_alsa_set_option,
-	.get_option = op_alsa_get_option
 };
 
-const char * const op_pcm_options[] = {
-	"device",
-	NULL
+const struct output_plugin_opt op_pcm_options[] = {
+	OPT(op_alsa, device),
+	{ NULL },
 };
 
 const int op_priority = 0;

--- a/ao.c
+++ b/ao.c
@@ -203,74 +203,86 @@ static int op_ao_buffer_space(void)
 	return libao_cur_buffer_space;
 }
 
-static int op_ao_set_option(int key, const char *val)
+static int op_ao_set_buffer_size(const char *val)
 {
 	long int ival;
-
-	switch (key) {
-	case 0:
-		if (str_to_int(val, &ival) || ival < 4096) {
-			errno = EINVAL;
-			return -OP_ERROR_ERRNO;
-		}
-		libao_buffer_space = ival;
-		break;
-	case 1:
-		free(libao_driver);
-		libao_driver = NULL;
-		if (val[0])
-			libao_driver = xstrdup(val);
-		break;
-	case 2:
-		if (str_to_int(val, &ival)) {
-			errno = EINVAL;
-			return -OP_ERROR_ERRNO;
-		}
-		wav_counter = ival;
-		break;
-	case 3:
-		free(wav_dir);
-		wav_dir = xstrdup(val);
-		break;
-	case 4:
-		free(libao_device_interface);
-		libao_device_interface = NULL;
-		if (val[0])
-			libao_device_interface = xstrdup(val);
-		break;
-	default:
-		return -OP_ERROR_NOT_OPTION;
+	if (str_to_int(val, &ival) || ival < 4096) {
+		errno = EINVAL;
+		return -OP_ERROR_ERRNO;
 	}
+	libao_buffer_space = ival;
 	return 0;
 }
 
-static int op_ao_get_option(int key, char **val)
+static int op_ao_get_buffer_size(char **val)
 {
-	switch (key) {
-	case 0:
-		*val = xnew(char, 22);
-		snprintf(*val, 22, "%d", libao_buffer_space);
-		break;
-	case 1:
-		if (libao_driver)
-			*val = xstrdup(libao_driver);
-		break;
-	case 2:
-		*val = xnew(char, 22);
-		snprintf(*val, 22, "%d", wav_counter);
-		break;
-	case 3:
-		if (wav_dir == NULL)
-			wav_dir = xstrdup(home_dir);
-		*val = expand_filename(wav_dir);
-		break;
-	case 4:
-		if (libao_device_interface)
-			*val = xstrdup(libao_device_interface);
-		break;
-	default:
-		return -OP_ERROR_NOT_OPTION;
+	*val = xnew(char, 22);
+	snprintf(*val, 22, "%d", libao_buffer_space);
+	return 0;
+}
+
+static int op_ao_set_driver(const char *val)
+{
+	free(libao_driver);
+	libao_driver = NULL;
+	if (val[0])
+		libao_driver = xstrdup(val);
+	return 0;
+}
+
+static int op_ao_get_driver(char **val)
+{
+	if (libao_driver)
+		*val = xstrdup(libao_driver);
+	return 0;
+}
+
+static int op_ao_set_wav_counter(const char *val)
+{
+	long int ival;
+	if (str_to_int(val, &ival)) {
+		errno = EINVAL;
+		return -OP_ERROR_ERRNO;
 	}
+	wav_counter = ival;
+	return 0;
+}
+
+static int op_ao_get_wav_counter(char **val)
+{
+	*val = xnew(char, 22);
+	snprintf(*val, 22, "%d", wav_counter);
+	return 0;
+}
+
+static int op_ao_set_wav_dir(const char *val)
+{
+	free(wav_dir);
+	wav_dir = xstrdup(val);
+	return 0;
+}
+
+static int op_ao_get_wav_dir(char **val)
+{
+	if (wav_dir == NULL)
+		wav_dir = xstrdup(home_dir);
+	*val = expand_filename(wav_dir);
+	return 0;
+}
+
+static int op_ao_set_device_interface(const char *val)
+{
+	free(libao_device_interface);
+	libao_device_interface = NULL;
+	if (val[0])
+		libao_device_interface = xstrdup(val);
+	return 0;
+}
+
+static int op_ao_get_device_interface(char **val)
+{
+	if (libao_device_interface)
+		*val = xstrdup(libao_device_interface);
 	return 0;
 }
 
@@ -281,17 +293,15 @@ const struct output_plugin_ops op_pcm_ops = {
 	.close = op_ao_close,
 	.write = op_ao_write,
 	.buffer_space = op_ao_buffer_space,
-	.set_option = op_ao_set_option,
-	.get_option = op_ao_get_option
 };
 
-const char * const op_pcm_options[] = {
-	"buffer_size",
-	"driver",
-	"wav_counter",
-	"wav_dir",
-	"device_interface",
-	NULL
+const struct output_plugin_opt op_pcm_options[] = {
+	OPT(op_ao, buffer_size),
+	OPT(op_ao, driver),
+	OPT(op_ao, wav_counter),
+	OPT(op_ao, wav_dir),
+	OPT(op_ao, device_interface),
+	{ NULL },
 };
 
 const int op_priority = 3;

--- a/arts.c
+++ b/arts.c
@@ -104,16 +104,6 @@ static int op_arts_buffer_space(void)
 	return space;
 }
 
-static int op_arts_set_option(int key, const char *val)
-{
-	return -OP_ERROR_NOT_OPTION;
-}
-
-static int op_arts_get_option(int key, char **val)
-{
-	return -OP_ERROR_NOT_OPTION;
-}
-
 const struct output_plugin_ops op_pcm_ops = {
 	.init = op_arts_init,
 	.exit = op_arts_exit,
@@ -123,12 +113,10 @@ const struct output_plugin_ops op_pcm_ops = {
 	.pause = op_arts_pause,
 	.unpause = op_arts_unpause,
 	.buffer_space = op_arts_buffer_space,
-	.set_option = op_arts_set_option,
-	.get_option = op_arts_get_option
 };
 
-const char * const op_pcm_options[] = {
-	NULL
+const struct output_plugin_opt op_pcm_options[] = {
+	{ NULL },
 };
 
 const int op_priority = 4;

--- a/cdio.c
+++ b/cdio.c
@@ -500,44 +500,27 @@ static char *libcdio_codec_profile(struct input_plugin_data *ip_data)
 	return xstrdup(discmode2str[cd_discmode]);
 }
 
-static int libcdio_set_option(int key, const char *val)
-{
 #ifdef HAVE_CDDB
+static int libcdio_set_cddb_url(const char *val)
+{
 	struct http_uri http_uri;
 	int use_http;
-#endif
-	switch (key) {
-#ifdef HAVE_CDDB
-	case 0:
-		if (parse_cddb_url(val, &http_uri, &use_http)) {
-			http_free_uri(&http_uri);
-			free(cddb_url);
-			cddb_url = xstrdup(val);
-		} else
-			return -IP_ERROR_INVALID_URI;
-		break;
-#endif
-	default:
-		return -IP_ERROR_NOT_OPTION;
-	}
+	if (!parse_cddb_url(val, &http_uri, &use_http))
+		return -IP_ERROR_INVALID_URI;
+	http_free_uri(&http_uri);
+	free(cddb_url);
+	cddb_url = xstrdup(val);
 	return 0;
 }
 
-static int libcdio_get_option(int key, char **val)
+static int libcdio_get_cddb_url(char **val)
 {
-	switch (key) {
-#ifdef HAVE_CDDB
-	case 0:
-		if (!cddb_url)
-			cddb_url = xstrdup("freedb.freedb.org:8880");
-		*val = xstrdup(cddb_url);
-		break;
-#endif
-	default:
-		return -IP_ERROR_NOT_OPTION;
-	}
+	if (!cddb_url)
+		cddb_url = xstrdup("freedb.freedb.org:8880");
+	*val = xstrdup(cddb_url);
 	return 0;
 }
+#endif
 
 const struct input_plugin_ops ip_ops = {
 	.open = libcdio_open,
@@ -549,15 +532,13 @@ const struct input_plugin_ops ip_ops = {
 	.bitrate = libcdio_bitrate,
 	.codec = libcdio_codec,
 	.codec_profile = libcdio_codec_profile,
-	.set_option = libcdio_set_option,
-	.get_option = libcdio_get_option
 };
 
-const char * const ip_options[] = {
+const struct input_plugin_opt ip_options[] = {
 #ifdef HAVE_CDDB
-	"cddb_url",
+	{ "cddb_url", libcdio_set_cddb_url, libcdio_get_cddb_url },
 #endif
-	NULL
+	{ NULL },
 };
 
 const int ip_priority = 50;

--- a/command_mode.c
+++ b/command_mode.c
@@ -459,7 +459,7 @@ static void cmd_set(char *arg)
 
 		opt = option_find(arg);
 		if (opt) {
-			opt->get(opt->id, buf);
+			opt->get(opt->data, buf);
 			info_msg("setting: '%s=%s'", arg, buf);
 		}
 	}
@@ -476,7 +476,7 @@ static void cmd_toggle(char *arg)
 		error_msg("%s is not toggle option", opt->name);
 		return;
 	}
-	opt->toggle(opt->id);
+	opt->toggle(opt->data);
 	help_win->changed = 1;
 	if (cur_view == TREE_VIEW) {
 		lib_track_win->changed = 1;
@@ -2471,7 +2471,7 @@ static void expand_options(const char *str)
 					tails = xnew(char *, 1);
 
 					buf[0] = 0;
-					opt->get(opt->id, buf);
+					opt->get(opt->data, buf);
 					tails[0] = xstrdup(buf);
 
 					tabexp.head = xstrdup(str);

--- a/cue.c
+++ b/cue.c
@@ -380,18 +380,6 @@ static char *cue_codec_profile(struct input_plugin_data *ip_data)
 }
 
 
-static int cue_set_option(int key, const char *val)
-{
-	return -IP_ERROR_NOT_OPTION;
-}
-
-
-static int cue_get_option(int key, char **val)
-{
-	return -IP_ERROR_NOT_OPTION;
-}
-
-
 const struct input_plugin_ops ip_ops = {
 	.open            = cue_open,
 	.close           = cue_close,
@@ -403,11 +391,9 @@ const struct input_plugin_ops ip_ops = {
 	.bitrate_current = cue_current_bitrate,
 	.codec           = cue_codec,
 	.codec_profile   = cue_codec_profile,
-	.set_option      = cue_set_option,
-	.get_option      = cue_get_option
 };
 
 const int ip_priority = 50;
 const char * const ip_extensions[] = { NULL };
 const char * const ip_mime_types[] = { "application/x-cue", NULL };
-const char * const ip_options[] = { NULL };
+const struct input_plugin_opt ip_options[] = { { NULL } };

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -684,4 +684,4 @@ const char *const ip_extensions[] = {
 	NULL
 };
 const char *const ip_mime_types[] = { NULL };
-const char * const ip_options[] = { NULL };
+const struct input_plugin_opt ip_options[] = { { NULL } };

--- a/flac.c
+++ b/flac.c
@@ -588,4 +588,4 @@ const struct input_plugin_ops ip_ops = {
 const int ip_priority = 50;
 const char * const ip_extensions[] = { "flac", "fla", NULL };
 const char * const ip_mime_types[] = { NULL };
-const char * const ip_options[] = { NULL };
+const struct input_plugin_opt ip_options[] = { { NULL } };

--- a/format_print.c
+++ b/format_print.c
@@ -259,7 +259,7 @@ static const char *str_val(const char *key, const struct format_option *fopts, c
 	} else {
 		opt = option_find_silent(key);
 		if (opt) {
-			opt->get(opt->id, buf);
+			opt->get(opt->data, buf);
 			val = buf;
 		}
 	}
@@ -361,7 +361,7 @@ static int format_eval_cond(struct expr* expr, const struct format_option *fopts
 		return !fo->empty;
 	opt = option_find_silent(key);
 	if (opt) {
-		opt->get(opt->id, buf);
+		opt->get(opt->data, buf);
 		if (strcmp(buf, "false") != 0 && strlen(buf) != 0)
 			return 1;
 	}

--- a/help.c
+++ b/help.c
@@ -230,7 +230,7 @@ void help_select(void)
 		break;
 	case HE_OPTION:
 		snprintf(buf, sizeof(buf), "set %s=", ent->option->name);
-		ent->option->get(ent->option->id, buf + strlen(buf));
+		ent->option->get(ent->option->data, buf + strlen(buf));
 		cmdline_set_text(buf);
 		enter_command_mode();
 		break;
@@ -251,7 +251,7 @@ void help_toggle(void)
 	switch (ent->type) {
 	case HE_OPTION:
 		if (ent->option->toggle) {
-			ent->option->toggle(ent->option->id);
+			ent->option->toggle(ent->option->data);
 			help_win->changed = 1;
 		}
 		break;

--- a/ip.h
+++ b/ip.h
@@ -95,8 +95,12 @@ struct input_plugin_ops {
 	long (*bitrate_current)(struct input_plugin_data *ip_data);
 	char *(*codec)(struct input_plugin_data *ip_data);
 	char *(*codec_profile)(struct input_plugin_data *ip_data);
-	int (*set_option)(int key, const char *val);
-	int (*get_option)(int key, char **val);
+};
+
+struct input_plugin_opt {
+	const char *name;
+	int (*set)(const char *val);
+	int (*get)(char **val);
 };
 
 /* symbols exported by plugin */
@@ -104,6 +108,6 @@ extern const struct input_plugin_ops ip_ops;
 extern const int ip_priority;
 extern const char * const ip_extensions[];
 extern const char * const ip_mime_types[];
-extern const char * const ip_options[];
+extern const struct input_plugin_opt ip_options[];
 
 #endif

--- a/mad.c
+++ b/mad.c
@@ -280,4 +280,4 @@ const char * const ip_extensions[] = { "mp3", "mp2", NULL };
 const char * const ip_mime_types[] = {
 	"audio/mpeg", "audio/x-mp3", "audio/x-mpeg", NULL
 };
-const char * const ip_options[] = { NULL };
+const struct input_plugin_opt ip_options[] = { { NULL } };

--- a/mikmod.c
+++ b/mikmod.c
@@ -172,4 +172,4 @@ const char * const ip_extensions[] = {
 	NULL
 };
 const char * const ip_mime_types[] = { NULL };
-const char * const ip_options[] = { NULL };
+const struct input_plugin_opt ip_options[] = { { NULL } };

--- a/mixer.h
+++ b/mixer.h
@@ -33,12 +33,16 @@ struct mixer_plugin_ops {
 	int (*get_fds)(int *fds);
 	int (*set_volume)(int l, int r);
 	int (*get_volume)(int *l, int *r);
-	int (*set_option)(int key, const char *val);
-	int (*get_option)(int key, char **val);
+};
+
+struct mixer_plugin_opt {
+	const char *name;
+	int (*set)(const char *val);
+	int (*get)(char **val);
 };
 
 /* symbols exported by plugin */
 extern const struct mixer_plugin_ops op_mixer_ops;
-extern const char * const op_mixer_options[];
+extern const struct mixer_plugin_opt op_mixer_options[];
 
 #endif

--- a/mixer_alsa.c
+++ b/mixer_alsa.c
@@ -180,37 +180,31 @@ static int alsa_mixer_get_volume(int *l, int *r)
 	return 0;
 }
 
-static int alsa_mixer_set_option(int key, const char *val)
+static int alsa_mixer_set_channel(const char *val)
 {
-	switch (key) {
-	case 0:
-		free(alsa_mixer_element);
-		alsa_mixer_element = xstrdup(val);
-		break;
-	case 1:
-		free(alsa_mixer_device);
-		alsa_mixer_device = xstrdup(val);
-		break;
-	default:
-		return -OP_ERROR_NOT_OPTION;
-	}
+	free(alsa_mixer_element);
+	alsa_mixer_element = xstrdup(val);
 	return 0;
 }
 
-static int alsa_mixer_get_option(int key, char **val)
+static int alsa_mixer_get_channel(char **val)
 {
-	switch (key) {
-	case 0:
-		if (alsa_mixer_element)
-			*val = xstrdup(alsa_mixer_element);
-		break;
-	case 1:
-		if (alsa_mixer_device)
-			*val = xstrdup(alsa_mixer_device);
-		break;
-	default:
-		return -OP_ERROR_NOT_OPTION;
-	}
+	if (alsa_mixer_element)
+		*val = xstrdup(alsa_mixer_element);
+	return 0;
+}
+
+static int alsa_mixer_set_device(const char *val)
+{
+	free(alsa_mixer_device);
+	alsa_mixer_device = xstrdup(val);
+	return 0;
+}
+
+static int alsa_mixer_get_device(char **val)
+{
+	if (alsa_mixer_device)
+		*val = xstrdup(alsa_mixer_device);
 	return 0;
 }
 
@@ -222,12 +216,10 @@ const struct mixer_plugin_ops op_mixer_ops = {
 	.get_fds = alsa_mixer_get_fds,
 	.set_volume = alsa_mixer_set_volume,
 	.get_volume = alsa_mixer_get_volume,
-	.set_option = alsa_mixer_set_option,
-	.get_option = alsa_mixer_get_option
 };
 
-const char * const op_mixer_options[] = {
-	"channel",
-	"device",
-	NULL
+const struct mixer_plugin_opt op_mixer_options[] = {
+	OPT(alsa_mixer, channel),
+	OPT(alsa_mixer, device),
+	{ NULL },
 };

--- a/mixer_oss.c
+++ b/mixer_oss.c
@@ -191,46 +191,40 @@ static int oss_mixer_get_volume(int *l, int *r)
 	}
 }
 
-static int oss_mixer_set_option(int key, const char *val)
+static int oss_mixer_set_channel(const char *val)
 {
-	switch (key) {
-	case 0:
-		if (strcasecmp(val, "pcm") == 0) {
-			oss_volume_controls_pcm = 1;
-		} else if (strcasecmp(val, "master") == 0) {
-			oss_volume_controls_pcm = 0;
-		} else {
-			errno = EINVAL;
-			return -OP_ERROR_ERRNO;
-		}
-		break;
-	case 1:
-		free(oss_mixer_device);
-		oss_mixer_device = xstrdup(val);
-		break;
-	default:
-		return -OP_ERROR_NOT_OPTION;
+	if (strcasecmp(val, "pcm") == 0) {
+		oss_volume_controls_pcm = 1;
+	} else if (strcasecmp(val, "master") == 0) {
+		oss_volume_controls_pcm = 0;
+	} else {
+		errno = EINVAL;
+		return -OP_ERROR_ERRNO;
 	}
 	return 0;
 }
 
-static int oss_mixer_get_option(int key, char **val)
+static int oss_mixer_get_channel(char **val)
 {
-	switch (key) {
-	case 0:
-		if (oss_volume_controls_pcm) {
-			*val = xstrdup("PCM");
-		} else {
-			*val = xstrdup("Master");
-		}
-		break;
-	case 1:
-		if (oss_mixer_device)
-			*val = xstrdup(oss_mixer_device);
-		break;
-	default:
-		return -OP_ERROR_NOT_OPTION;
+	if (oss_volume_controls_pcm) {
+		*val = xstrdup("PCM");
+	} else {
+		*val = xstrdup("Master");
 	}
+	return 0;
+}
+
+static int oss_mixer_set_device(const char *val)
+{
+	free(oss_mixer_device);
+	oss_mixer_device = xstrdup(val);
+	return 0;
+}
+
+static int oss_mixer_get_device(char **val)
+{
+	if (oss_mixer_device)
+		*val = xstrdup(oss_mixer_device);
 	return 0;
 }
 
@@ -241,12 +235,10 @@ const struct mixer_plugin_ops op_mixer_ops = {
 	.close = oss_mixer_close,
 	.set_volume = oss_mixer_set_volume,
 	.get_volume = oss_mixer_get_volume,
-	.set_option = oss_mixer_set_option,
-	.get_option = oss_mixer_get_option
 };
 
-const char * const op_mixer_options[] = {
-	"channel",
-	"device",
-	NULL
+const struct mixer_plugin_opt op_mixer_options[] = {
+	OPT(oss_mixer, channel),
+	OPT(oss_mixer, device),
+	{ NULL },
 };

--- a/mixer_sun.c
+++ b/mixer_sun.c
@@ -49,8 +49,6 @@ static int sun_mixer_open(int *);
 static int sun_mixer_close(void);
 static int sun_mixer_set_volume(int, int);
 static int sun_mixer_get_volume(int *, int *);
-static int sun_mixer_set_option(int, const char *);
-static int sun_mixer_get_option(int, char **);
 
 static int mixer_open(const char *dev)
 {
@@ -240,40 +238,32 @@ static int sun_mixer_get_volume(int *l, int *r)
 	return 0;
 }
 
-static int sun_mixer_set_option(int key, const char *val)
+static int sun_mixer_set_channel(const char *val)
 {
-	switch (key) {
-	case 0:
-		if (sun_mixer_channel != NULL)
-			free(sun_mixer_channel);
-		sun_mixer_channel = xstrdup(val);
-		break;
-	case 1:
-		free(sun_mixer_device);
-		sun_mixer_device = xstrdup(val);
-		break;
-	default:
-		return -OP_ERROR_NOT_OPTION;
-	}
-
+	if (sun_mixer_channel != NULL)
+		free(sun_mixer_channel);
+	sun_mixer_channel = xstrdup(val);
 	return 0;
 }
 
-static int sun_mixer_get_option(int key, char **val)
+static int sun_mixer_get_channel(char **val)
 {
-	switch (key) {
-	case 0:
-		if (sun_mixer_channel)
-			*val = xstrdup(sun_mixer_channel);
-		break;
-	case 1:
-		if (sun_mixer_device)
-			*val = xstrdup(sun_mixer_device);
-		break;
-	default:
-		return -OP_ERROR_NOT_OPTION;
-	}
+	if (sun_mixer_channel)
+		*val = xstrdup(sun_mixer_channel);
+	return 0;
+}
 
+static int sun_mixer_set_device(const char *val)
+{
+	free(sun_mixer_device);
+	sun_mixer_device = xstrdup(val);
+	return 0;
+}
+
+static int sun_mixer_get_device(char **val)
+{
+	if (sun_mixer_device)
+		*val = xstrdup(sun_mixer_device);
 	return 0;
 }
 
@@ -284,12 +274,10 @@ const struct mixer_plugin_ops op_mixer_ops = {
 	.close = sun_mixer_close,
 	.set_volume = sun_mixer_set_volume,
 	.get_volume = sun_mixer_get_volume,
-	.set_option = sun_mixer_set_option,
-	.get_option = sun_mixer_get_option
 };
 
-const char * const op_mixer_options[] = {
-	"channel",
-	"device",
-	NULL
+const struct mixer_plugin_opt op_mixer_options[] = {
+	OPT(sun_mixer, channel),
+	OPT(sun_mixer, device),
+	{ NULL },
 };

--- a/modplug.c
+++ b/modplug.c
@@ -240,4 +240,4 @@ const char * const ip_extensions[] = {
 	"psm", NULL
 };
 const char * const ip_mime_types[] = { NULL };
-const char * const ip_options[] = { NULL };
+const struct input_plugin_opt ip_options[] = { { NULL } };

--- a/mp4.c
+++ b/mp4.c
@@ -600,4 +600,4 @@ const struct input_plugin_ops ip_ops = {
 const int ip_priority = 50;
 const char * const ip_extensions[] = { "mp4", "m4a", "m4b", NULL };
 const char * const ip_mime_types[] = { /*"audio/mp4", "audio/mp4a-latm",*/ NULL };
-const char * const ip_options[] = { NULL };
+const struct input_plugin_opt ip_options[] = { { NULL } };

--- a/mpc.c
+++ b/mpc.c
@@ -460,4 +460,4 @@ const struct input_plugin_ops ip_ops = {
 const int ip_priority = 50;
 const char *const ip_extensions[] = { "mpc", "mpp", "mp+", NULL };
 const char *const ip_mime_types[] = { "audio/x-musepack", NULL };
-const char *const ip_options[] = { NULL };
+const struct input_plugin_opt ip_options[] = { { NULL } };

--- a/op.h
+++ b/op.h
@@ -60,13 +60,20 @@ struct output_plugin_ops {
 	int (*pause)(void);
 	int (*unpause)(void);
 
-	int (*set_option)(int key, const char *val);
-	int (*get_option)(int key, char **val);
+};
+
+#define OPT(prefix, name) { #name, prefix ## _set_ ## name, \
+	prefix ## _get_ ## name }
+
+struct output_plugin_opt {
+	const char *name;
+	int (*set)(const char *val);
+	int (*get)(char **val);
 };
 
 /* symbols exported by plugin */
 extern const struct output_plugin_ops op_pcm_ops;
-extern const char * const op_pcm_options[];
+extern const struct output_plugin_opt op_pcm_options[];
 extern const int op_priority;
 
 #endif

--- a/options.c
+++ b/options.c
@@ -256,24 +256,24 @@ static const struct {
 
 /* callbacks for normal options {{{ */
 
-static void get_device(unsigned int id, char *buf)
+static void get_device(void *data, char *buf)
 {
 	strcpy(buf, cdda_device);
 }
 
-static void set_device(unsigned int id, const char *buf)
+static void set_device(void *data, const char *buf)
 {
 	free(cdda_device);
 	cdda_device = expand_filename(buf);
 }
 
 #define SECOND_SIZE (44100 * 16 / 8 * 2)
-static void get_buffer_seconds(unsigned int id, char *buf)
+static void get_buffer_seconds(void *data, char *buf)
 {
 	buf_int(buf, (player_get_buffer_chunks() * CHUNK_SIZE + SECOND_SIZE / 2) / SECOND_SIZE);
 }
 
-static void set_buffer_seconds(unsigned int id, const char *buf)
+static void set_buffer_seconds(void *data, const char *buf)
 {
 	int sec;
 
@@ -281,12 +281,12 @@ static void set_buffer_seconds(unsigned int id, const char *buf)
 		player_set_buffer_chunks((sec * SECOND_SIZE + CHUNK_SIZE / 2) / CHUNK_SIZE);
 }
 
-static void get_scroll_offset(unsigned int id, char *buf)
+static void get_scroll_offset(void *data, char *buf)
 {
 	buf_int(buf, scroll_offset);
 }
 
-static void set_scroll_offset(unsigned int id, const char *buf)
+static void set_scroll_offset(void *data, const char *buf)
 {
 	int offset;
 
@@ -294,12 +294,12 @@ static void set_scroll_offset(unsigned int id, const char *buf)
 		scroll_offset = offset;
 }
 
-static void get_rewind_offset(unsigned int id, char *buf)
+static void get_rewind_offset(void *data, char *buf)
 {
 	buf_int(buf, rewind_offset);
 }
 
-static void set_rewind_offset(unsigned int id, const char *buf)
+static void set_rewind_offset(void *data, const char *buf)
 {
 	int offset;
 
@@ -307,23 +307,23 @@ static void set_rewind_offset(unsigned int id, const char *buf)
 		rewind_offset = offset;
 }
 
-static void get_id3_default_charset(unsigned int id, char *buf)
+static void get_id3_default_charset(void *data, char *buf)
 {
 	strcpy(buf, id3_default_charset);
 }
 
-static void get_icecast_default_charset(unsigned int id, char *buf)
+static void get_icecast_default_charset(void *data, char *buf)
 {
 	strcpy(buf, icecast_default_charset);
 }
 
-static void set_id3_default_charset(unsigned int id, const char *buf)
+static void set_id3_default_charset(void *data, const char *buf)
 {
 	free(id3_default_charset);
 	id3_default_charset = xstrdup(buf);
 }
 
-static void set_icecast_default_charset(unsigned int id, const char *buf)
+static void set_icecast_default_charset(void *data, const char *buf)
 {
 	free(icecast_default_charset);
 	icecast_default_charset = xstrdup(buf);
@@ -461,12 +461,12 @@ static void sort_keys_to_str(const sort_key_t *keys, char *buf, size_t bufsize)
 	buf[pos] = 0;
 }
 
-static void get_lib_sort(unsigned int id, char *buf)
+static void get_lib_sort(void *data, char *buf)
 {
 	strcpy(buf, lib_editable.sort_str);
 }
 
-static void set_lib_sort(unsigned int id, const char *buf)
+static void set_lib_sort(void *data, const char *buf)
 {
 	sort_key_t *keys = parse_sort_keys(buf);
 
@@ -478,12 +478,12 @@ static void set_lib_sort(unsigned int id, const char *buf)
 	}
 }
 
-static void get_pl_sort(unsigned int id, char *buf)
+static void get_pl_sort(void *data, char *buf)
 {
 	strcpy(buf, pl_editable.sort_str);
 }
 
-static void set_pl_sort(unsigned int id, const char *buf)
+static void set_pl_sort(void *data, const char *buf)
 {
 	sort_key_t *keys = parse_sort_keys(buf);
 
@@ -495,7 +495,7 @@ static void set_pl_sort(unsigned int id, const char *buf)
 	}
 }
 
-static void get_output_plugin(unsigned int id, char *buf)
+static void get_output_plugin(void *data, char *buf)
 {
 	const char *value = op_get_current();
 
@@ -503,7 +503,7 @@ static void get_output_plugin(unsigned int id, char *buf)
 		strcpy(buf, value);
 }
 
-static void set_output_plugin(unsigned int id, const char *buf)
+static void set_output_plugin(void *data, const char *buf)
 {
 	if (ui_initialized) {
 		if (!soft_vol)
@@ -517,13 +517,13 @@ static void set_output_plugin(unsigned int id, const char *buf)
 	}
 }
 
-static void get_passwd(unsigned int id, char *buf)
+static void get_passwd(void *data, char *buf)
 {
 	if (server_password)
 		strcpy(buf, server_password);
 }
 
-static void set_passwd(unsigned int id, const char *buf)
+static void set_passwd(void *data, const char *buf)
 {
 	int len = strlen(buf);
 
@@ -538,12 +538,12 @@ static void set_passwd(unsigned int id, const char *buf)
 	}
 }
 
-static void get_replaygain_preamp(unsigned int id, char *buf)
+static void get_replaygain_preamp(void *data, char *buf)
 {
 	sprintf(buf, "%f", replaygain_preamp);
 }
 
-static void set_replaygain_preamp(unsigned int id, const char *buf)
+static void set_replaygain_preamp(void *data, const char *buf)
 {
 	double val;
 	char *end;
@@ -556,12 +556,12 @@ static void set_replaygain_preamp(unsigned int id, const char *buf)
 	player_set_rg_preamp(val);
 }
 
-static void get_softvol_state(unsigned int id, char *buf)
+static void get_softvol_state(void *data, char *buf)
 {
 	sprintf(buf, "%d %d", soft_vol_l, soft_vol_r);
 }
 
-static void set_softvol_state(unsigned int id, const char *buf)
+static void set_softvol_state(void *data, const char *buf)
 {
 	char buffer[OPTION_MAX_SIZE];
 	char *ptr;
@@ -585,13 +585,13 @@ err:
 	error_msg("two integers in range 0..100 expected");
 }
 
-static void get_status_display_program(unsigned int id, char *buf)
+static void get_status_display_program(void *data, char *buf)
 {
 	if (status_display_program)
 		strcpy(buf, status_display_program);
 }
 
-static void set_status_display_program(unsigned int id, const char *buf)
+static void set_status_display_program(void *data, const char *buf)
 {
 	free(status_display_program);
 	status_display_program = NULL;
@@ -603,63 +603,63 @@ static void set_status_display_program(unsigned int id, const char *buf)
 
 /* callbacks for toggle options {{{ */
 
-static void get_auto_reshuffle(unsigned int id, char *buf)
+static void get_auto_reshuffle(void *data, char *buf)
 {
 	strcpy(buf, bool_names[auto_reshuffle]);
 }
 
-static void set_auto_reshuffle(unsigned int id, const char *buf)
+static void set_auto_reshuffle(void *data, const char *buf)
 {
 	parse_bool(buf, &auto_reshuffle);
 }
 
-static void toggle_auto_reshuffle(unsigned int id)
+static void toggle_auto_reshuffle(void *data)
 {
 	auto_reshuffle ^= 1;
 }
 
-static void get_follow(unsigned int id, char *buf)
+static void get_follow(void *data, char *buf)
 {
 	strcpy(buf, bool_names[follow]);
 }
 
-static void set_follow(unsigned int id, const char *buf)
+static void set_follow(void *data, const char *buf)
 {
 	if (!parse_bool(buf, &follow))
 		return;
 	update_statusline();
 }
 
-static void toggle_follow(unsigned int id)
+static void toggle_follow(void *data)
 {
 	follow ^= 1;
 	update_statusline();
 }
 
-static void get_continue(unsigned int id, char *buf)
+static void get_continue(void *data, char *buf)
 {
 	strcpy(buf, bool_names[player_cont]);
 }
 
-static void set_continue(unsigned int id, const char *buf)
+static void set_continue(void *data, const char *buf)
 {
 	if (!parse_bool(buf, &player_cont))
 		return;
 	update_statusline();
 }
 
-static void toggle_continue(unsigned int id)
+static void toggle_continue(void *data)
 {
 	player_cont ^= 1;
 	update_statusline();
 }
 
-static void get_repeat_current(unsigned int id, char *buf)
+static void get_repeat_current(void *data, char *buf)
 {
 	strcpy(buf, bool_names[player_repeat_current]);
 }
 
-static void set_repeat_current(unsigned int id, const char *buf)
+static void set_repeat_current(void *data, const char *buf)
 {
 	int old = player_repeat_current;
 	if (!parse_bool(buf, &player_repeat_current))
@@ -669,24 +669,24 @@ static void set_repeat_current(unsigned int id, const char *buf)
 	update_statusline();
 }
 
-static void toggle_repeat_current(unsigned int id)
+static void toggle_repeat_current(void *data)
 {
 	player_repeat_current ^= 1;
 	mpris_loop_status_changed();
 	update_statusline();
 }
 
-static void get_confirm_run(unsigned int id, char *buf)
+static void get_confirm_run(void *data, char *buf)
 {
 	strcpy(buf, bool_names[confirm_run]);
 }
 
-static void set_confirm_run(unsigned int id, const char *buf)
+static void set_confirm_run(void *data, const char *buf)
 {
 	parse_bool(buf, &confirm_run);
 }
 
-static void toggle_confirm_run(unsigned int id)
+static void toggle_confirm_run(void *data)
 {
 	confirm_run ^= 1;
 }
@@ -695,30 +695,30 @@ const char * const view_names[NR_VIEWS + 1] = {
 	"tree", "sorted", "playlist", "queue", "browser", "filters", "settings", NULL
 };
 
-static void get_play_library(unsigned int id, char *buf)
+static void get_play_library(void *data, char *buf)
 {
 	strcpy(buf, bool_names[play_library]);
 }
 
-static void set_play_library(unsigned int id, const char *buf)
+static void set_play_library(void *data, const char *buf)
 {
 	if (!parse_bool(buf, &play_library))
 		return;
 	update_statusline();
 }
 
-static void toggle_play_library(unsigned int id)
+static void toggle_play_library(void *data)
 {
 	play_library ^= 1;
 	update_statusline();
 }
 
-static void get_play_sorted(unsigned int id, char *buf)
+static void get_play_sorted(void *data, char *buf)
 {
 	strcpy(buf, bool_names[play_sorted]);
 }
 
-static void set_play_sorted(unsigned int id, const char *buf)
+static void set_play_sorted(void *data, const char *buf)
 {
 	int tmp;
 
@@ -732,7 +732,7 @@ static void set_play_sorted(unsigned int id, const char *buf)
 	update_statusline();
 }
 
-static void toggle_play_sorted(unsigned int id)
+static void toggle_play_sorted(void *data)
 {
 	editable_lock();
 	play_sorted = play_sorted ^ 1;
@@ -748,35 +748,35 @@ static void toggle_play_sorted(unsigned int id)
 	update_statusline();
 }
 
-static void get_smart_artist_sort(unsigned int id, char *buf)
+static void get_smart_artist_sort(void *data, char *buf)
 {
 	strcpy(buf, bool_names[smart_artist_sort]);
 }
 
-static void set_smart_artist_sort(unsigned int id, const char *buf)
+static void set_smart_artist_sort(void *data, const char *buf)
 {
 	if (parse_bool(buf, &smart_artist_sort))
 		tree_sort_artists();
 }
 
-static void toggle_smart_artist_sort(unsigned int id)
+static void toggle_smart_artist_sort(void *data)
 {
 	smart_artist_sort ^= 1;
 	tree_sort_artists();
 }
 
-static void get_display_artist_sort_name(unsigned int id, char *buf)
+static void get_display_artist_sort_name(void *data, char *buf)
 {
 	strcpy(buf, bool_names[display_artist_sort_name]);
 }
 
-static void set_display_artist_sort_name(unsigned int id, const char *buf)
+static void set_display_artist_sort_name(void *data, const char *buf)
 {
 	parse_bool(buf, &display_artist_sort_name);
 	lib_tree_win->changed = 1;
 }
 
-static void toggle_display_artist_sort_name(unsigned int id)
+static void toggle_display_artist_sort_name(void *data)
 {
 	display_artist_sort_name ^= 1;
 	lib_tree_win->changed = 1;
@@ -786,12 +786,12 @@ const char * const aaa_mode_names[] = {
 	"all", "artist", "album", NULL
 };
 
-static void get_aaa_mode(unsigned int id, char *buf)
+static void get_aaa_mode(void *data, char *buf)
 {
 	strcpy(buf, aaa_mode_names[aaa_mode]);
 }
 
-static void set_aaa_mode(unsigned int id, const char *buf)
+static void set_aaa_mode(void *data, const char *buf)
 {
 	int tmp;
 
@@ -802,7 +802,7 @@ static void set_aaa_mode(unsigned int id, const char *buf)
 	update_statusline();
 }
 
-static void toggle_aaa_mode(unsigned int id)
+static void toggle_aaa_mode(void *data)
 {
 	editable_lock();
 
@@ -815,12 +815,12 @@ static void toggle_aaa_mode(unsigned int id)
 	update_statusline();
 }
 
-static void get_repeat(unsigned int id, char *buf)
+static void get_repeat(void *data, char *buf)
 {
 	strcpy(buf, bool_names[repeat]);
 }
 
-static void set_repeat(unsigned int id, const char *buf)
+static void set_repeat(void *data, const char *buf)
 {
 	int old = repeat;
 	if (!parse_bool(buf, &repeat))
@@ -830,7 +830,7 @@ static void set_repeat(unsigned int id, const char *buf)
 	update_statusline();
 }
 
-static void toggle_repeat(unsigned int id)
+static void toggle_repeat(void *data)
 {
 	repeat ^= 1;
 	if (!player_repeat_current)
@@ -842,12 +842,12 @@ static const char * const replaygain_names[] = {
 	"disabled", "track", "album", "track-preferred", "album-preferred", NULL
 };
 
-static void get_replaygain(unsigned int id, char *buf)
+static void get_replaygain(void *data, char *buf)
 {
 	strcpy(buf, replaygain_names[replaygain]);
 }
 
-static void set_replaygain(unsigned int id, const char *buf)
+static void set_replaygain(void *data, const char *buf)
 {
 	int tmp;
 
@@ -856,17 +856,17 @@ static void set_replaygain(unsigned int id, const char *buf)
 	player_set_rg(tmp);
 }
 
-static void toggle_replaygain(unsigned int id)
+static void toggle_replaygain(void *data)
 {
 	player_set_rg((replaygain + 1) % 5);
 }
 
-static void get_replaygain_limit(unsigned int id, char *buf)
+static void get_replaygain_limit(void *data, char *buf)
 {
 	strcpy(buf, bool_names[replaygain_limit]);
 }
 
-static void set_replaygain_limit(unsigned int id, const char *buf)
+static void set_replaygain_limit(void *data, const char *buf)
 {
 	int tmp;
 
@@ -875,39 +875,39 @@ static void set_replaygain_limit(unsigned int id, const char *buf)
 	player_set_rg_limit(tmp);
 }
 
-static void toggle_replaygain_limit(unsigned int id)
+static void toggle_replaygain_limit(void *data)
 {
 	player_set_rg_limit(replaygain_limit ^ 1);
 }
 
-static void get_resume(unsigned int id, char *buf)
+static void get_resume(void *data, char *buf)
 {
 	strcpy(buf, bool_names[resume_cmus]);
 }
 
-static void set_resume(unsigned int id, const char *buf)
+static void set_resume(void *data, const char *buf)
 {
 	parse_bool(buf, &resume_cmus);
 }
 
-static void toggle_resume(unsigned int id)
+static void toggle_resume(void *data)
 {
 	resume_cmus ^= 1;
 }
 
-static void get_show_hidden(unsigned int id, char *buf)
+static void get_show_hidden(void *data, char *buf)
 {
 	strcpy(buf, bool_names[show_hidden]);
 }
 
-static void set_show_hidden(unsigned int id, const char *buf)
+static void set_show_hidden(void *data, const char *buf)
 {
 	if (!parse_bool(buf, &show_hidden))
 		return;
 	browser_reload();
 }
 
-static void toggle_show_hidden(unsigned int id)
+static void toggle_show_hidden(void *data)
 {
 	show_hidden ^= 1;
 	browser_reload();
@@ -915,7 +915,7 @@ static void toggle_show_hidden(unsigned int id)
 
 static void set_show_all_tracks_int(int); /* defined below */
 
-static void get_auto_expand_albums_follow(unsigned int id, char *buf)
+static void get_auto_expand_albums_follow(void *data, char *buf)
 {
 	strcpy(buf, bool_names[auto_expand_albums_follow]);
 }
@@ -927,19 +927,19 @@ static void set_auto_expand_albums_follow_int(int value)
 		set_show_all_tracks_int(1);
 }
 
-static void set_auto_expand_albums_follow(unsigned int id, const char *buf)
+static void set_auto_expand_albums_follow(void *data, const char *buf)
 {
 	int tmp = 0;
 	parse_bool(buf, &tmp);
 	set_auto_expand_albums_follow_int(tmp);
 }
 
-static void toggle_auto_expand_albums_follow(unsigned int id)
+static void toggle_auto_expand_albums_follow(void *data)
 {
 	set_auto_expand_albums_follow_int(!auto_expand_albums_follow);
 }
 
-static void get_auto_expand_albums_search(unsigned int id, char *buf)
+static void get_auto_expand_albums_search(void *data, char *buf)
 {
 	strcpy(buf, bool_names[auto_expand_albums_search]);
 }
@@ -951,19 +951,19 @@ static void set_auto_expand_albums_search_int(int value)
 		set_show_all_tracks_int(1);
 }
 
-static void set_auto_expand_albums_search(unsigned int id, const char *buf)
+static void set_auto_expand_albums_search(void *data, const char *buf)
 {
 	int tmp = 0;
 	parse_bool(buf, &tmp);
 	set_auto_expand_albums_search_int(tmp);
 }
 
-static void toggle_auto_expand_albums_search(unsigned int id)
+static void toggle_auto_expand_albums_search(void *data)
 {
 	set_auto_expand_albums_search_int(!auto_expand_albums_search);
 }
 
-static void get_auto_expand_albums_selcur(unsigned int id, char *buf)
+static void get_auto_expand_albums_selcur(void *data, char *buf)
 {
 	strcpy(buf, bool_names[auto_expand_albums_selcur]);
 }
@@ -975,20 +975,20 @@ static void set_auto_expand_albums_selcur_int(int value)
 		set_show_all_tracks_int(1);
 }
 
-static void set_auto_expand_albums_selcur(unsigned int id, const char *buf)
+static void set_auto_expand_albums_selcur(void *data, const char *buf)
 {
 	int tmp = 0;
 	parse_bool(buf, &tmp);
 	set_auto_expand_albums_selcur_int(tmp);
 }
 
-static void toggle_auto_expand_albums_selcur(unsigned int id)
+static void toggle_auto_expand_albums_selcur(void *data)
 {
 	set_auto_expand_albums_selcur_int(!auto_expand_albums_selcur);
 }
 
 
-static void get_show_all_tracks(unsigned int id, char *buf)
+static void get_show_all_tracks(void *data, char *buf)
 {
 	strcpy(buf, bool_names[show_all_tracks]);
 }
@@ -1010,92 +1010,92 @@ static void set_show_all_tracks_int(int value)
 	tree_sel_update(0);
 }
 
-static void set_show_all_tracks(unsigned int id, const char *buf)
+static void set_show_all_tracks(void *data, const char *buf)
 {
 	int tmp = 0;
 	parse_bool(buf, &tmp);
 	set_show_all_tracks_int(tmp);
 }
 
-static void toggle_show_all_tracks(unsigned int id)
+static void toggle_show_all_tracks(void *data)
 {
 	set_show_all_tracks_int(!show_all_tracks);
 }
 
-static void get_show_current_bitrate(unsigned int id, char *buf)
+static void get_show_current_bitrate(void *data, char *buf)
 {
 	strcpy(buf, bool_names[show_current_bitrate]);
 }
 
-static void set_show_current_bitrate(unsigned int id, const char *buf)
+static void set_show_current_bitrate(void *data, const char *buf)
 {
 	if (parse_bool(buf, &show_current_bitrate))
 		update_statusline();
 }
 
-static void toggle_show_current_bitrate(unsigned int id)
+static void toggle_show_current_bitrate(void *data)
 {
 	show_current_bitrate ^= 1;
 	update_statusline();
 }
 
-static void get_show_playback_position(unsigned int id, char *buf)
+static void get_show_playback_position(void *data, char *buf)
 {
 	strcpy(buf, bool_names[show_playback_position]);
 }
 
-static void set_show_playback_position(unsigned int id, const char *buf)
+static void set_show_playback_position(void *data, const char *buf)
 {
 	if (!parse_bool(buf, &show_playback_position))
 		return;
 	update_statusline();
 }
 
-static void toggle_show_playback_position(unsigned int id)
+static void toggle_show_playback_position(void *data)
 {
 	show_playback_position ^= 1;
 	update_statusline();
 }
 
-static void get_show_remaining_time(unsigned int id, char *buf)
+static void get_show_remaining_time(void *data, char *buf)
 {
 	strcpy(buf, bool_names[show_remaining_time]);
 }
 
-static void set_show_remaining_time(unsigned int id, const char *buf)
+static void set_show_remaining_time(void *data, const char *buf)
 {
 	if (!parse_bool(buf, &show_remaining_time))
 		return;
 	update_statusline();
 }
 
-static void toggle_show_remaining_time(unsigned int id)
+static void toggle_show_remaining_time(void *data)
 {
 	show_remaining_time ^= 1;
 	update_statusline();
 }
 
-static void get_set_term_title(unsigned int id, char *buf)
+static void get_set_term_title(void *data, char *buf)
 {
 	strcpy(buf, bool_names[set_term_title]);
 }
 
-static void set_set_term_title(unsigned int id, const char *buf)
+static void set_set_term_title(void *data, const char *buf)
 {
 	parse_bool(buf, &set_term_title);
 }
 
-static void toggle_set_term_title(unsigned int id)
+static void toggle_set_term_title(void *data)
 {
 	set_term_title ^= 1;
 }
 
-static void get_shuffle(unsigned int id, char *buf)
+static void get_shuffle(void *data, char *buf)
 {
 	strcpy(buf, bool_names[shuffle]);
 }
 
-static void set_shuffle(unsigned int id, const char *buf)
+static void set_shuffle(void *data, const char *buf)
 {
 	int old = shuffle;
 	if (!parse_bool(buf, &shuffle))
@@ -1105,14 +1105,14 @@ static void set_shuffle(unsigned int id, const char *buf)
 	update_statusline();
 }
 
-static void toggle_shuffle(unsigned int id)
+static void toggle_shuffle(void *data)
 {
 	shuffle ^= 1;
 	mpris_shuffle_changed();
 	update_statusline();
 }
 
-static void get_softvol(unsigned int id, char *buf)
+static void get_softvol(void *data, char *buf)
 {
 	strcpy(buf, bool_names[soft_vol]);
 }
@@ -1127,7 +1127,7 @@ static void do_set_softvol(int soft)
 	update_statusline();
 }
 
-static void set_softvol(unsigned int id, const char *buf)
+static void set_softvol(void *data, const char *buf)
 {
 	int soft;
 
@@ -1136,37 +1136,37 @@ static void set_softvol(unsigned int id, const char *buf)
 	do_set_softvol(soft);
 }
 
-static void toggle_softvol(unsigned int id)
+static void toggle_softvol(void *data)
 {
 	do_set_softvol(soft_vol ^ 1);
 }
 
-static void get_wrap_search(unsigned int id, char *buf)
+static void get_wrap_search(void *data, char *buf)
 {
 	strcpy(buf, bool_names[wrap_search]);
 }
 
-static void set_wrap_search(unsigned int id, const char *buf)
+static void set_wrap_search(void *data, const char *buf)
 {
 	parse_bool(buf, &wrap_search);
 }
 
-static void toggle_wrap_search(unsigned int id)
+static void toggle_wrap_search(void *data)
 {
 	wrap_search ^= 1;
 }
 
-static void get_skip_track_info(unsigned int id, char *buf)
+static void get_skip_track_info(void *data, char *buf)
 {
 	strcpy(buf, bool_names[skip_track_info]);
 }
 
-static void set_skip_track_info(unsigned int id, const char *buf)
+static void set_skip_track_info(void *data, const char *buf)
 {
 	parse_bool(buf, &skip_track_info);
 }
 
-static void toggle_skip_track_info(unsigned int id)
+static void toggle_skip_track_info(void *data)
 {
 	skip_track_info ^= 1;
 }
@@ -1193,34 +1193,34 @@ void update_mouse(void)
 	}
 }
 
-static void get_mouse(unsigned int id, char *buf)
+static void get_mouse(void *data, char *buf)
 {
 	strcpy(buf, bool_names[mouse]);
 }
 
-static void set_mouse(unsigned int id, const char *buf)
+static void set_mouse(void *data, const char *buf)
 {
 	parse_bool(buf, &mouse);
 	update_mouse();
 }
 
-static void toggle_mouse(unsigned int id)
+static void toggle_mouse(void *data)
 {
 	mouse ^= 1;
 	update_mouse();
 }
 
-static void get_mpris(unsigned int id, char *buf)
+static void get_mpris(void *data, char *buf)
 {
 	strcpy(buf, bool_names[mpris]);
 }
 
-static void set_mpris(unsigned int id, const char *buf)
+static void set_mpris(void *data, const char *buf)
 {
 	parse_bool(buf, &mpris);
 }
 
-static void toggle_mpris(unsigned int id)
+static void toggle_mpris(void *data)
 {
 	mpris ^= 1;
 }
@@ -1236,11 +1236,9 @@ static const char * const color_enum_names[1 + 8 * 2 + 1] = {
 	NULL
 };
 
-static void get_color(unsigned int id, char *buf)
+static void get_color(void *data, char *buf)
 {
-	int val;
-
-	val = colors[id];
+	int val = *(int *)data;
 	if (val < 16) {
 		strcpy(buf, color_enum_names[val + 1]);
 	} else {
@@ -1248,21 +1246,21 @@ static void get_color(unsigned int id, char *buf)
 	}
 }
 
-static void set_color(unsigned int id, const char *buf)
+static void set_color(void *data, const char *buf)
 {
 	int color;
 
 	if (!parse_enum(buf, -1, 255, color_enum_names, &color))
 		return;
 
-	colors[id] = color;
+	*(int *)data = color;
 	update_colors();
 	update_full();
 }
 
-static void get_attr(unsigned int id, char *buf)
+static void get_attr(void *data, char *buf)
 {
-	int attr = attrs[id];
+	int attr = *(int *)data;
 
 	if (attr == 0) {
 		strcpy(buf, "default");
@@ -1287,7 +1285,7 @@ static void get_attr(unsigned int id, char *buf)
 	buf[strlen(buf) - 1] = '\0';
 }
 
-static void set_attr(unsigned int id, const char *buf)
+static void set_attr(void *data, const char *buf)
 {
 	int attr = 0;
 	size_t i = 0;
@@ -1322,7 +1320,7 @@ static void set_attr(unsigned int id, const char *buf)
 		length++;
 	} while (buf[i - 1] != '\0');
 
-	attrs[id] = attr;
+	*(int *)data = attr;
 	update_colors();
 	update_full();
 }
@@ -1364,16 +1362,16 @@ static char **id_to_fmt(enum format_id id)
 	return NULL;
 }
 
-static void get_format(unsigned int id, char *buf)
+static void get_format(void *data, char *buf)
 {
-	char **fmtp = id_to_fmt(id);
+	char **fmtp = data;
 
 	strcpy(buf, *fmtp);
 }
 
-static void set_format(unsigned int id, const char *buf)
+static void set_format(void *data, const char *buf)
 {
-	char **fmtp = id_to_fmt(id);
+	char **fmtp = data;
 
 	if (!track_format_valid(buf)) {
 		error_msg("invalid format string");
@@ -1485,14 +1483,14 @@ static const char * const attr_names[NR_ATTRS] = {
 LIST_HEAD(option_head);
 int nr_options = 0;
 
-void option_add(const char *name, unsigned int id, opt_get_cb get,
+void option_add(const char *name, const void *data, opt_get_cb get,
 		opt_set_cb set, opt_toggle_cb toggle, unsigned int flags)
 {
 	struct cmus_opt *opt = xnew(struct cmus_opt, 1);
 	struct list_head *item;
 
 	opt->name = name;
-	opt->id = id;
+	opt->data = (void *)data;
 	opt->get = get;
 	opt->set = set;
 	opt->toggle = toggle;
@@ -1535,7 +1533,7 @@ void option_set(const char *name, const char *value)
 	struct cmus_opt *opt = option_find(name);
 
 	if (opt)
-		opt->set(opt->id, value);
+		opt->set(opt->data, value);
 }
 
 void options_add(void)
@@ -1543,18 +1541,21 @@ void options_add(void)
 	int i;
 
 	for (i = 0; simple_options[i].name; i++)
-		option_add(simple_options[i].name, 0, simple_options[i].get,
+		option_add(simple_options[i].name, NULL, simple_options[i].get,
 				simple_options[i].set, simple_options[i].toggle,
 				simple_options[i].flags);
 
 	for (i = 0; i < NR_FMTS; i++)
-		option_add(str_defaults[i].name, i, get_format, set_format, NULL, 0);
+		option_add(str_defaults[i].name, id_to_fmt(i), get_format,
+				set_format, NULL, 0);
 
 	for (i = 0; i < NR_COLORS; i++)
-		option_add(color_names[i], i, get_color, set_color, NULL, 0);
+		option_add(color_names[i], &colors[i], get_color, set_color,
+				NULL, 0);
 
 	for (i = 0; i < NR_ATTRS; i++)
-		option_add(attr_names[i], i, get_attr, set_attr, NULL, 0);
+		option_add(attr_names[i], &attrs[i], get_attr, set_attr, NULL,
+				0);
 
 	ip_add_options();
 	op_add_options();
@@ -1623,7 +1624,7 @@ void options_exit(void)
 		char buf[OPTION_MAX_SIZE];
 
 		buf[0] = 0;
-		opt->get(opt->id, buf);
+		opt->get(opt->data, buf);
 		fprintf(f, "set %s=%s\n", opt->name, buf);
 	}
 

--- a/options.h
+++ b/options.h
@@ -23,9 +23,9 @@
 
 #define OPTION_MAX_SIZE	4096
 
-typedef void (*opt_get_cb)(unsigned int id, char *buf);
-typedef void (*opt_set_cb)(unsigned int id, const char *buf);
-typedef void (*opt_toggle_cb)(unsigned int id);
+typedef void (*opt_get_cb)(void *data, char *buf);
+typedef void (*opt_set_cb)(void *data, const char *buf);
+typedef void (*opt_toggle_cb)(void *data);
 
 enum {
 	OPT_PROGRAM_PATH = 1 << 0,
@@ -37,12 +37,10 @@ struct cmus_opt {
 	const char *name;
 
 	/* If there are many similar options you should write generic get(),
-	 * set() and optionally toggle() and set id to index of option array or
-	 * what ever.
-	 *
-	 * Useful for colors, format strings and plugin options.
+	 * set() and optionally toggle() and distinguish the concrete option
+	 * via this pointer.
 	 */
-	unsigned int id;
+	void *data;
 
 	opt_get_cb get;
 	opt_set_cb set;
@@ -195,7 +193,7 @@ void resume_load(void);
 /* save resume file */
 void resume_exit(void);
 
-void option_add(const char *name, unsigned int id, opt_get_cb get,
+void option_add(const char *name, const void *data, opt_get_cb get,
 		opt_set_cb set, opt_toggle_cb toggle, unsigned int flags);
 struct cmus_opt *option_find(const char *name);
 struct cmus_opt *option_find_silent(const char *name);

--- a/opus.c
+++ b/opus.c
@@ -330,4 +330,4 @@ const struct input_plugin_ops ip_ops = {
 const int ip_priority = 50;
 const char * const ip_extensions[] = { "opus", NULL };
 const char * const ip_mime_types[] = { NULL };
-const char * const ip_options[] = { NULL };
+const struct input_plugin_opt ip_options[] = { { NULL } };

--- a/oss.c
+++ b/oss.c
@@ -224,29 +224,17 @@ static int oss_buffer_space(void)
 	return space;
 }
 
-static int op_oss_set_option(int key, const char *val)
+static int op_oss_set_device(const char *val)
 {
-	switch (key) {
-	case 0:
-		free(oss_dsp_device);
-		oss_dsp_device = xstrdup(val);
-		break;
-	default:
-		return -OP_ERROR_NOT_OPTION;
-	}
+	free(oss_dsp_device);
+	oss_dsp_device = xstrdup(val);
 	return 0;
 }
 
-static int op_oss_get_option(int key, char **val)
+static int op_oss_get_device(char **val)
 {
-	switch (key) {
-	case 0:
-		if (oss_dsp_device)
-			*val = xstrdup(oss_dsp_device);
-		break;
-	default:
-		return -OP_ERROR_NOT_OPTION;
-	}
+	if (oss_dsp_device)
+		*val = xstrdup(oss_dsp_device);
 	return 0;
 }
 
@@ -259,13 +247,11 @@ const struct output_plugin_ops op_pcm_ops = {
 	.pause = oss_pause,
 	.unpause = oss_unpause,
 	.buffer_space = oss_buffer_space,
-	.set_option = op_oss_set_option,
-	.get_option = op_oss_get_option
 };
 
-const char * const op_pcm_options[] = {
-	"device",
-	NULL
+const struct output_plugin_opt op_pcm_options[] = {
+	OPT(op_oss, device),
+	{ NULL },
 };
 
 const int op_priority = 1;

--- a/pulse.c
+++ b/pulse.c
@@ -468,16 +468,6 @@ static int op_pulse_unpause(void)
 	return _pa_stream_cork(0);
 }
 
-static int op_pulse_set_option(int key, const char *val)
-{
-	return -OP_ERROR_NOT_OPTION;
-}
-
-static int op_pulse_get_option(int key, char **val)
-{
-	return -OP_ERROR_NOT_OPTION;
-}
-
 static int op_pulse_mixer_init(void)
 {
 	if (!pa_channel_map_init_stereo(&pa_cmap))
@@ -561,27 +551,15 @@ static int op_pulse_mixer_get_volume(int *l, int *r)
 	return rc;
 }
 
-static int op_pulse_mixer_set_option(int key, const char *val)
+static int op_pulse_set_restore_volume(const char *val)
 {
-	switch (key) {
-	case 0:
-		pa_restore_volume = is_freeform_true(val);
-		break;
-	default:
-		return -OP_ERROR_NOT_OPTION;
-	}
+	pa_restore_volume = is_freeform_true(val);
 	return 0;
 }
 
-static int op_pulse_mixer_get_option(int key, char **val)
+static int op_pulse_get_restore_volume(char **val)
 {
-	switch (key) {
-	case 0:
-		*val = xstrdup(pa_restore_volume ? "1" : "0");
-		break;
-	default:
-		return -OP_ERROR_NOT_OPTION;
-	}
+	*val = xstrdup(pa_restore_volume ? "1" : "0");
 	return 0;
 }
 
@@ -595,8 +573,6 @@ const struct output_plugin_ops op_pcm_ops = {
 	.buffer_space	= op_pulse_buffer_space,
 	.pause		= op_pulse_pause,
 	.unpause	= op_pulse_unpause,
-	.set_option	= op_pulse_set_option,
-	.get_option	= op_pulse_get_option
 };
 
 const struct mixer_plugin_ops op_mixer_ops = {
@@ -607,18 +583,15 @@ const struct mixer_plugin_ops op_mixer_ops = {
 	.get_fds	= op_pulse_mixer_get_fds,
 	.set_volume	= op_pulse_mixer_set_volume,
 	.get_volume	= op_pulse_mixer_get_volume,
-	.set_option	= op_pulse_mixer_set_option,
-	.get_option	= op_pulse_mixer_get_option
 };
 
-const char * const op_pcm_options[] = {
-	NULL
+const struct output_plugin_opt op_pcm_options[] = {
+	{ NULL },
 };
 
-const char * const op_mixer_options[] = {
-	"restore_volume",
-	NULL
+const struct mixer_plugin_opt op_mixer_options[] = {
+	OPT(op_pulse, restore_volume),
+	{ NULL },
 };
 
 const int op_priority = -2;
-

--- a/roar.c
+++ b/roar.c
@@ -259,41 +259,6 @@ static int op_roar_unpause(void) {
 }
 
 
-static int op_roar_set_option(int key, const char *val)
-{
-	switch (key) {
-	case 0:
-		free(host);
-		host = xstrdup(val);
-		break;
-	case 1:
-		free(role);
-		role = xstrdup(val);
-		_set_role();
-		break;
-	default:
-		return -OP_ERROR_NOT_OPTION;
-	}
-	return 0;
-}
-
-static int op_roar_get_option(int key, char **val)
-{
-	switch (key) {
-	case 0:
-		if (host != NULL)
-			*val = xstrdup(host);
-		break;
-	case 1:
-		if (role != NULL)
-			*val = xstrdup(role);
-		break;
-	default:
-		return -OP_ERROR_NOT_OPTION;
-	}
-	return 0;
-}
-
 static int op_roar_mixer_open(int *volume_max)
 {
 	*volume_max = MIXER_BASE_VOLUME;
@@ -317,6 +282,7 @@ static int op_roar_mixer_set_volume(int l, int r)
 
 	return 0;
 }
+
 static int op_roar_mixer_get_volume(int *l, int *r)
 {
 	float lf, rf;
@@ -338,13 +304,33 @@ static int op_roar_mixer_get_volume(int *l, int *r)
 	return 0;
 }
 
-static int op_roar_mixer_set_option(int key, const char *val)
+static int op_roar_set_server(const char *val)
 {
-	return -OP_ERROR_NOT_OPTION;
+	free(host);
+	host = xstrdup(val);
+	return 0;
 }
-static int op_roar_mixer_get_option(int key, char **val)
+
+static int op_roar_get_server(char **val)
 {
-	return -OP_ERROR_NOT_OPTION;
+	if (host != NULL)
+		*val = xstrdup(host);
+	return 0;
+}
+
+
+static int op_roar_set_role(const char *val)
+{
+	free(host);
+	host = xstrdup(val);
+	return 0;
+}
+
+static int op_roar_get_role(char **val)
+{
+	if (role != NULL)
+		*val = xstrdup(role);
+	return 0;
 }
 
 const struct output_plugin_ops op_pcm_ops = {
@@ -357,14 +343,12 @@ const struct output_plugin_ops op_pcm_ops = {
 	.buffer_space = op_roar_buffer_space,
 	.pause = op_roar_pause,
 	.unpause = op_roar_unpause,
-	.set_option = op_roar_set_option,
-	.get_option = op_roar_get_option
 };
 
-const char * const op_pcm_options[] = {
-	"server",
-	"role",
-	NULL
+const struct output_plugin_opt op_pcm_options[] = {
+	OPT(op_roar, server),
+	OPT(op_roar, role),
+	{ NULL },
 };
 
 const struct mixer_plugin_ops op_mixer_ops = {
@@ -375,12 +359,10 @@ const struct mixer_plugin_ops op_mixer_ops = {
 	.get_fds = NULL,
 	.set_volume = op_roar_mixer_set_volume,
 	.get_volume = op_roar_mixer_get_volume,
-	.set_option = op_roar_mixer_set_option,
-	.get_option = op_roar_mixer_get_option
 };
 
-const char * const op_mixer_options[] = {
-	NULL
+const struct mixer_plugin_opt op_mixer_options[] = {
+	{ NULL },
 };
 
 const int op_priority = -1;

--- a/server.c
+++ b/server.c
@@ -120,7 +120,7 @@ static int cmd_status(struct client *client)
 	for (i = 0; export_options[i]; i++) {
 		opt = option_find(export_options[i]);
 		if (opt) {
-			opt->get(opt->id, optbuf);
+			opt->get(opt->data, optbuf);
 			gbuf_addf(&buf, "set %s %s\n", opt->name, optbuf);
 		}
 	}

--- a/sndio.c
+++ b/sndio.c
@@ -223,16 +223,6 @@ static int sndio_mixer_close(void)
 	return OP_ERROR_SUCCESS;
 }
 
-static int sndio_mixer_set_option(int key, const char *val)
-{
-	return -OP_ERROR_NOT_OPTION;
-}
-
-static int sndio_mixer_get_option(int key, char **val)
-{
-	return -OP_ERROR_NOT_OPTION;
-}
-
 const struct output_plugin_ops op_pcm_ops = {
 	.init = sndio_init,
 	.exit = sndio_exit,
@@ -242,8 +232,6 @@ const struct output_plugin_ops op_pcm_ops = {
 	.pause = sndio_pause,
 	.unpause = sndio_unpause,
 	.buffer_space = sndio_buffer_space,
-	.set_option = op_sndio_set_option,
-	.get_option = op_sndio_get_option
 };
 
 const struct mixer_plugin_ops op_mixer_ops = {
@@ -253,16 +241,14 @@ const struct mixer_plugin_ops op_mixer_ops = {
 	.close = sndio_mixer_close,
 	.set_volume = sndio_mixer_set_volume,
 	.get_volume = sndio_mixer_get_volume,
-	.set_option = sndio_mixer_set_option,
-	.get_option = sndio_mixer_get_option
 };
 
-const char * const op_pcm_options[] = {
-	NULL
+const struct output_plugin_opt op_pcm_options[] = {
+	{ NULL },
 };
 
-const char * const op_mixer_options[] = {
-	NULL
+const struct mixer_plugin_opt op_mixer_options[] = {
+	{ NULL },
 };
 
 const int op_priority = 2;

--- a/sun.c
+++ b/sun.c
@@ -217,31 +217,17 @@ static int sun_buffer_space(void)
 	return sp;
 }
 
-static int op_sun_set_option(int key, const char *val)
+static int op_sun_set_device(const char *val)
 {
-	switch (key) {
-	case 0:
-		free(sun_audio_device);
-		sun_audio_device = xstrdup(val);
-		break;
-	default:
-		return -OP_ERROR_NOT_OPTION;
-	}
-
+	free(sun_audio_device);
+	sun_audio_device = xstrdup(val);
 	return 0;
 }
 
-static int op_sun_get_option(int key, char **val)
+static int op_sun_get_device(char **val)
 {
-	switch (key) {
-	case 0:
-		if (sun_audio_device)
-			*val = xstrdup(sun_audio_device);
-		break;
-	default:
-		return -OP_ERROR_NOT_OPTION;
-	}
-
+	if (sun_audio_device)
+		*val = xstrdup(sun_audio_device);
 	return 0;
 }
 
@@ -254,13 +240,11 @@ const struct output_plugin_ops op_pcm_ops = {
 	.pause = sun_pause,
 	.unpause = sun_unpause,
 	.buffer_space = sun_buffer_space,
-	.set_option = op_sun_set_option,
-	.get_option = op_sun_get_option
 };
 
-const char * const op_pcm_options[] = {
-	"device",
-	NULL
+const struct output_plugin_opt op_pcm_options[] = {
+	OPT(op_sun, device),
+	{ NULL },
 };
 
 const int op_priority = 0;

--- a/ui_curses.c
+++ b/ui_curses.c
@@ -945,7 +945,7 @@ static void print_help(struct window *win, int row, struct iter *iter)
 	case HE_OPTION:
 		opt = e->option;
 		snprintf(buf, sizeof(buf), " %-29s ", opt->name);
-		opt->get(opt->id, buf + strlen(buf));
+		opt->get(opt->data, buf + strlen(buf));
 		break;
 	}
 	pos = format_str(print_buffer, buf, COLS - 1);

--- a/vorbis.c
+++ b/vorbis.c
@@ -410,4 +410,4 @@ const struct input_plugin_ops ip_ops = {
 const int ip_priority = 50;
 const char * const ip_extensions[] = { "ogg", "oga", "ogx", NULL };
 const char * const ip_mime_types[] = { "application/ogg", "audio/x-ogg", NULL };
-const char * const ip_options[] = { NULL };
+const struct input_plugin_opt ip_options[] = { { NULL } };

--- a/vtx.c
+++ b/vtx.c
@@ -185,4 +185,4 @@ const struct input_plugin_ops ip_ops = {
 const int ip_priority = 50;
 const char * const ip_extensions[] = {"vtx", NULL};
 const char * const ip_mime_types[] = { NULL };
-const char * const ip_options[] = { NULL };
+const struct input_plugin_opt ip_options[] = { { NULL } };

--- a/wav.c
+++ b/wav.c
@@ -413,4 +413,4 @@ const struct input_plugin_ops ip_ops = {
 const int ip_priority = 50;
 const char * const ip_extensions[] = { "wav", NULL };
 const char * const ip_mime_types[] = { NULL };
-const char * const ip_options[] = { NULL };
+const struct input_plugin_opt ip_options[] = { { NULL } };

--- a/wavpack.c
+++ b/wavpack.c
@@ -430,4 +430,4 @@ const struct input_plugin_ops ip_ops = {
 const int ip_priority = 50;
 const char * const ip_extensions[] = { "wv", NULL };
 const char * const ip_mime_types[] = { "audio/x-wavpack", NULL };
-const char * const ip_options[] = { NULL };
+const struct input_plugin_opt ip_options[] = { { NULL } };


### PR DESCRIPTION
Multiple options can be handled by a single function via an opaque argument that is passed to the handler. This PR changes the type of this argument from `unsigned` to `void *`.

This has the following advantages:

* The code is smaller: This PR removes 200 lines.
* The code is more robust: Plugins used to figure which option to handle by comparing the passed integer to the position of the option name in an array. This meant that the array layout was significant and had to be kept in sync with the option handler functions. The new version uses the same design used inside the `option.c` file where each option gets its own function.
* The new version allows #442 to be implemented with a single list since the position of a plugin in the list is no longer significant and the list can be reordered at runtime.