### PR TITLE
remove public use of player_info_lock

### DIFF
--- a/cmus.h
+++ b/cmus.h
@@ -92,4 +92,9 @@ int cmus_playlist_for_each(const char *buf, int size, int reverse,
 void cmus_next(void);
 void cmus_prev(void);
 
+extern int cmus_next_track_request_fd;
+struct track_info *cmus_get_next_track(void);
+void cmus_provide_next_track(void);
+void cmus_track_request_init(void);
+
 #endif

--- a/command_mode.c
+++ b/command_mode.c
@@ -70,25 +70,18 @@ void view_clear(int view)
 	case TREE_VIEW:
 	case SORTED_VIEW:
 		worker_remove_jobs(JOB_TYPE_LIB);
-		editable_lock();
 		editable_clear(&lib_editable);
 
 		/* FIXME: make this optional? */
 		lib_clear_store();
-
-		editable_unlock();
 		break;
 	case PLAYLIST_VIEW:
 		worker_remove_jobs(JOB_TYPE_PL);
-		editable_lock();
 		editable_clear(&pl_editable);
-		editable_unlock();
 		break;
 	case QUEUE_VIEW:
 		worker_remove_jobs(JOB_TYPE_QUEUE);
-		editable_lock();
 		editable_clear(&pq_editable);
-		editable_unlock();
 		break;
 	default:
 		info_msg(":clear only works in views 1-4");
@@ -156,18 +149,14 @@ void view_load(int view, char *arg)
 	case TREE_VIEW:
 	case SORTED_VIEW:
 		worker_remove_jobs(JOB_TYPE_LIB);
-		editable_lock();
 		editable_clear(&lib_editable);
-		editable_unlock();
 		cmus_add(lib_add_track, name, FILE_TYPE_PL, JOB_TYPE_LIB, 0);
 		free(lib_filename);
 		lib_filename = name;
 		break;
 	case PLAYLIST_VIEW:
 		worker_remove_jobs(JOB_TYPE_PL);
-		editable_lock();
 		editable_clear(&pl_editable);
-		editable_unlock();
 		cmus_add(pl_add_track, name, FILE_TYPE_PL, JOB_TYPE_PL, 0);
 		free(pl_filename);
 		pl_filename = name;
@@ -195,10 +184,8 @@ static void do_save(for_each_ti_cb for_each_ti, const char *arg, char **filename
 		return;
 	}
 
-	editable_lock();
 	if (save_ti(for_each_ti, filename) == -1)
 		error_msg("saving '%s': %s", filename, strerror(errno));
-	editable_unlock();
 }
 
 void view_save(int view, char *arg, int to_stdout, int filtered, int extended)
@@ -561,23 +548,17 @@ err:
 
 static void cmd_factivate(char *arg)
 {
-	editable_lock();
 	filters_activate_names(arg);
-	editable_unlock();
 }
 
 static void cmd_live_filter(char *arg)
 {
-	editable_lock();
 	filters_set_live(arg);
-	editable_unlock();
 }
 
 static void cmd_filter(char *arg)
 {
-	editable_lock();
 	filters_set_anonymous(arg);
-	editable_unlock();
 }
 
 static void cmd_fset(char *arg)
@@ -592,7 +573,6 @@ static void cmd_help(char *arg)
 
 static void cmd_invert(char *arg)
 {
-	editable_lock();
 	switch (cur_view) {
 	case SORTED_VIEW:
 		editable_invert_marks(&lib_editable);
@@ -606,12 +586,10 @@ static void cmd_invert(char *arg)
 	default:
 		info_msg(":invert only works in views 2-4");
 	}
-	editable_unlock();
 }
 
 static void cmd_mark(char *arg)
 {
-	editable_lock();
 	switch (cur_view) {
 	case SORTED_VIEW:
 		editable_mark(&lib_editable, arg);
@@ -625,12 +603,10 @@ static void cmd_mark(char *arg)
 	default:
 		info_msg(":mark only works in views 2-4");
 	}
-	editable_unlock();
 }
 
 static void cmd_unmark(char *arg)
 {
-	editable_lock();
 	switch (cur_view) {
 	case SORTED_VIEW:
 		editable_unmark(&lib_editable);
@@ -644,7 +620,6 @@ static void cmd_unmark(char *arg)
 	default:
 		info_msg(":unmark only works in views 2-4");
 	}
-	editable_unlock();
 }
 
 static void cmd_update_cache(char *arg)
@@ -774,10 +749,8 @@ static void cmd_quit(char *arg)
 
 static void cmd_reshuffle(char *arg)
 {
-	editable_lock();
 	lib_reshuffle();
 	pl_reshuffle();
-	editable_unlock();
 }
 
 static void cmd_source(char *arg)
@@ -1021,7 +994,6 @@ static void cmd_run(char *arg)
 	}
 
 	/* collect selected files (struct track_info) */
-	editable_lock();
 	switch (cur_view) {
 	case TREE_VIEW:
 		_tree_for_each_sel(add_ti, &sel, 0);
@@ -1036,7 +1008,6 @@ static void cmd_run(char *arg)
 		_editable_for_each_sel(&pq_editable, add_ti, &sel, 0);
 		break;
 	}
-	editable_unlock();
 
 	if (sel.tis_nr == 0) {
 		/* no files selected, do nothing */
@@ -1159,7 +1130,6 @@ static void cmd_echo(char *arg)
 	/* get only the first selected track */
 	sel_ti = NULL;
 
-	editable_lock();
 	switch (cur_view) {
 	case TREE_VIEW:
 		_tree_for_each_sel(get_one_ti, &sel_ti, 0);
@@ -1174,7 +1144,6 @@ static void cmd_echo(char *arg)
 		_editable_for_each_sel(&pq_editable, get_one_ti, &sel_ti, 0);
 		break;
 	}
-	editable_unlock();
 
 	if (sel_ti == NULL)
 		return;
@@ -1349,7 +1318,6 @@ static void cmd_pwd(char *arg)
 
 static void cmd_rand(char *arg)
 {
-	editable_lock();
 	switch (cur_view) {
 	case TREE_VIEW:
 		break;
@@ -1363,7 +1331,6 @@ static void cmd_rand(char *arg)
 		editable_rand(&pq_editable);
 		break;
 	}
-	editable_unlock();
 }
 
 static void cmd_search_next(char *arg)
@@ -1449,9 +1416,7 @@ static void cmd_win_add_l(char *arg)
 
 	if (cur_view <= QUEUE_VIEW) {
 		struct wrapper_cb_data add = { lib_add_track };
-		editable_lock();
 		view_for_each_sel[cur_view](wrapper_cb, &add, 0);
-		editable_unlock();
 	} else if (cur_view == BROWSER_VIEW) {
 		add_from_browser(lib_add_track, JOB_TYPE_LIB);
 	}
@@ -1465,9 +1430,7 @@ static void cmd_win_add_p(char *arg)
 
 	if (cur_view <= QUEUE_VIEW) {
 		struct wrapper_cb_data add = { pl_add_track };
-		editable_lock();
 		view_for_each_sel[cur_view](wrapper_cb, &add, 0);
-		editable_unlock();
 	} else if (cur_view == BROWSER_VIEW) {
 		add_from_browser(pl_add_track, JOB_TYPE_PL);
 	}
@@ -1480,9 +1443,7 @@ static void cmd_win_add_Q(char *arg)
 
 	if (cur_view <= QUEUE_VIEW) {
 		struct wrapper_cb_data add = { play_queue_prepend };
-		editable_lock();
 		view_for_each_sel[cur_view](wrapper_cb, &add, 1);
-		editable_unlock();
 	} else if (cur_view == BROWSER_VIEW) {
 		add_from_browser(play_queue_prepend, JOB_TYPE_QUEUE);
 	}
@@ -1495,9 +1456,7 @@ static void cmd_win_add_q(char *arg)
 
 	if (cur_view <= QUEUE_VIEW) {
 		struct wrapper_cb_data add = { play_queue_append };
-		editable_lock();
 		view_for_each_sel[cur_view](wrapper_cb, &add, 0);
-		editable_unlock();
 	} else if (cur_view == BROWSER_VIEW) {
 		add_from_browser(play_queue_append, JOB_TYPE_QUEUE);
 	}
@@ -1518,7 +1477,6 @@ static void cmd_win_activate(char *arg)
 		shuffle_root = &pl_shuffle_root;
 	}
 
-	editable_lock();
 	switch (cur_view) {
 	case TREE_VIEW:
 		info = tree_activate_selected();
@@ -1544,7 +1502,6 @@ static void cmd_win_activate(char *arg)
 		help_select();
 		break;
 	}
-	editable_unlock();
 
 	if (info) {
 		if (shuffle)
@@ -1561,10 +1518,7 @@ static void cmd_win_activate(char *arg)
 
 static void cmd_win_mv_after(char *arg)
 {
-	editable_lock();
 	switch (cur_view) {
-	case TREE_VIEW:
-		break;
 	case SORTED_VIEW:
 		editable_move_after(&lib_editable);
 		break;
@@ -1574,22 +1528,12 @@ static void cmd_win_mv_after(char *arg)
 	case QUEUE_VIEW:
 		editable_move_after(&pq_editable);
 		break;
-	case BROWSER_VIEW:
-		break;
-	case FILTERS_VIEW:
-		break;
-	case HELP_VIEW:
-		break;
 	}
-	editable_unlock();
 }
 
 static void cmd_win_mv_before(char *arg)
 {
-	editable_lock();
 	switch (cur_view) {
-	case TREE_VIEW:
-		break;
 	case SORTED_VIEW:
 		editable_move_before(&lib_editable);
 		break;
@@ -1599,19 +1543,11 @@ static void cmd_win_mv_before(char *arg)
 	case QUEUE_VIEW:
 		editable_move_before(&pq_editable);
 		break;
-	case BROWSER_VIEW:
-		break;
-	case FILTERS_VIEW:
-		break;
-	case HELP_VIEW:
-		break;
 	}
-	editable_unlock();
 }
 
 static void cmd_win_remove(char *arg)
 {
-	editable_lock();
 	switch (cur_view) {
 	case TREE_VIEW:
 		tree_remove_sel();
@@ -1635,12 +1571,10 @@ static void cmd_win_remove(char *arg)
 		help_remove();
 		break;
 	}
-	editable_unlock();
 }
 
 static void cmd_win_sel_cur(char *arg)
 {
-	editable_lock();
 	switch (cur_view) {
 	case TREE_VIEW:
 		tree_sel_current(auto_expand_albums_selcur);
@@ -1651,42 +1585,23 @@ static void cmd_win_sel_cur(char *arg)
 	case PLAYLIST_VIEW:
 		pl_sel_current();
 		break;
-	case QUEUE_VIEW:
-		break;
-	case BROWSER_VIEW:
-		break;
-	case FILTERS_VIEW:
-		break;
-	case HELP_VIEW:
-		break;
 	}
-	editable_unlock();
 }
 
 static void cmd_win_toggle(char *arg)
 {
 	switch (cur_view) {
 	case TREE_VIEW:
-		editable_lock();
 		tree_toggle_expand_artist();
-		editable_unlock();
 		break;
 	case SORTED_VIEW:
-		editable_lock();
 		editable_toggle_mark(&lib_editable);
-		editable_unlock();
 		break;
 	case PLAYLIST_VIEW:
-		editable_lock();
 		editable_toggle_mark(&pl_editable);
-		editable_unlock();
 		break;
 	case QUEUE_VIEW:
-		editable_lock();
 		editable_toggle_mark(&pq_editable);
-		editable_unlock();
-		break;
-	case BROWSER_VIEW:
 		break;
 	case FILTERS_VIEW:
 		filters_toggle_filter();
@@ -1699,23 +1614,17 @@ static void cmd_win_toggle(char *arg)
 
 static void cmd_win_scroll_down(char *arg)
 {
-	editable_lock();
 	window_scroll_down(current_win());
-	editable_unlock();
 }
 
 static void cmd_win_scroll_up(char *arg)
 {
-	editable_lock();
 	window_scroll_up(current_win());
-	editable_unlock();
 }
 
 static void cmd_win_bottom(char *arg)
 {
-	editable_lock();
 	window_goto_bottom(current_win());
-	editable_unlock();
 }
 
 static void cmd_win_down(char *arg)
@@ -1730,67 +1639,48 @@ static void cmd_win_down(char *arg)
 		}
 	}
 
-	editable_lock();
 	window_down(current_win(), num_rows);
-	editable_unlock();
 }
 
 static void cmd_win_next(char *arg)
 {
-	if (cur_view == TREE_VIEW) {
-		editable_lock();
+	if (cur_view == TREE_VIEW)
 		tree_toggle_active_window();
-		editable_unlock();
-	}
 }
 
 static void cmd_win_pg_down(char *arg)
 {
-	editable_lock();
 	window_page_down(current_win());
-	editable_unlock();
 }
 
 static void cmd_win_pg_up(char *arg)
 {
-	editable_lock();
 	window_page_up(current_win());
-	editable_unlock();
 }
 
 static void cmd_win_hf_pg_down(char *arg)
 {
-	editable_lock();
 	window_half_page_down(current_win());
-	editable_unlock();
 }
 
 static void cmd_win_hf_pg_up(char *arg)
 {
-	editable_lock();
 	window_half_page_up(current_win());
-	editable_unlock();
 }
 
 static void cmd_win_pg_top(char *arg)
 {
-	editable_lock();
 	window_page_top(current_win());
-	editable_unlock();
 }
 
 static void cmd_win_pg_bottom(char *arg)
 {
-	editable_lock();
 	window_page_bottom(current_win());
-	editable_unlock();
 }
 
 static void cmd_win_pg_middle(char *arg)
 {
-	editable_lock();
 	window_page_middle(current_win());
-	editable_unlock();
 }
 
 static void cmd_win_update_cache(char *arg)
@@ -1801,9 +1691,7 @@ static void cmd_win_update_cache(char *arg)
 	if (cur_view != TREE_VIEW && cur_view != SORTED_VIEW)
 		return;
 
-	editable_lock();
 	view_for_each_sel[cur_view](add_ti, &sel, 0);
-	editable_unlock();
 	if (sel.tis_nr == 0)
 		return;
 	sel.tis[sel.tis_nr] = NULL;
@@ -1812,9 +1700,7 @@ static void cmd_win_update_cache(char *arg)
 
 static void cmd_win_top(char *arg)
 {
-	editable_lock();
 	window_goto_top(current_win());
-	editable_unlock();
 }
 
 static void cmd_win_up(char *arg)
@@ -1829,9 +1715,7 @@ static void cmd_win_up(char *arg)
 		}
 	}
 
-	editable_lock();
 	window_up(current_win(), num_rows);
-	editable_unlock();
 }
 
 static void cmd_win_update(char *arg)
@@ -1842,9 +1726,7 @@ static void cmd_win_update(char *arg)
 		cmus_update_lib();
 		break;
 	case PLAYLIST_VIEW:
-		editable_lock();
 		editable_clear(&pl_editable);
-		editable_unlock();
 		cmus_add(pl_add_track, pl_filename, FILE_TYPE_PL, JOB_TYPE_PL, 0);
 		break;
 	case BROWSER_VIEW:
@@ -1963,12 +1845,11 @@ static void cmd_lqueue(char *arg)
 		}
 		count = val;
 	}
-	editable_lock();
 	nmax = count_albums();
 	if (count > nmax)
 		count = nmax;
 	if (!count)
-		goto unlock;
+		return;
 
 	r = rand_array(count, nmax);
 	album = to_album(rb_first(&to_artist(rb_first(&lib_artist_root))->album_root));
@@ -2004,8 +1885,6 @@ static void cmd_lqueue(char *arg)
 		free(a);
 		item = next;
 	} while (item != &head);
-unlock:
-	editable_unlock();
 }
 
 struct track_list {
@@ -2029,11 +1908,10 @@ static void cmd_tqueue(char *arg)
 		}
 		count = val;
 	}
-	editable_lock();
 	if (count > lib_editable.nr_tracks)
 		count = lib_editable.nr_tracks;
 	if (!count)
-		goto unlock;
+		return;
 
 	r = rand_array(count, lib_editable.nr_tracks);
 	item = lib_editable.head.next;
@@ -2059,8 +1937,6 @@ static void cmd_tqueue(char *arg)
 		free(t);
 		item = next;
 	} while (item != &head);
-unlock:
-	editable_unlock();
 }
 
 /* tab exp {{{

--- a/editable.c
+++ b/editable.c
@@ -26,8 +26,6 @@
 #include "mergesort.h"
 #include "xmalloc.h"
 
-pthread_mutex_t editable_mutex = CMUS_MUTEX_INITIALIZER;
-
 static const struct searchable_ops simple_search_ops = {
 	.get_prev = simple_track_get_prev,
 	.get_next = simple_track_get_next,

--- a/editable.h
+++ b/editable.h
@@ -39,8 +39,6 @@ struct editable {
 	void (*free_track)(struct list_head *item);
 };
 
-extern pthread_mutex_t editable_mutex;
-
 void editable_init(struct editable *e, void (*free_track)(struct list_head *item));
 void editable_add(struct editable *e, struct simple_track *track);
 void editable_add_before(struct editable *e, struct simple_track *track);
@@ -70,8 +68,5 @@ static inline void editable_track_to_iter(struct editable *e, struct simple_trac
 	iter->data1 = track;
 	iter->data2 = NULL;
 }
-
-#define editable_lock() cmus_mutex_lock(&editable_mutex)
-#define editable_unlock() cmus_mutex_unlock(&editable_mutex)
 
 #endif

--- a/job.c
+++ b/job.c
@@ -539,7 +539,6 @@ static void free_update_cache_job(void *data)
 
 static void job_handle_update_cache_result(struct job_result *res)
 {
-	player_info_lock();
 	for (size_t i = 0; i < res->update_cache_num; i++) {
 		struct track_info *new, *old = res->update_cache_ti[i];
 
@@ -560,7 +559,6 @@ static void job_handle_update_cache_result(struct job_result *res)
 		if (new)
 			track_info_unref(new);
 	}
-	player_info_unlock();
 	free(res->update_cache_ti);
 }
 

--- a/job.c
+++ b/job.c
@@ -16,6 +16,7 @@
  * along with this program; if not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "utils.h"
 #include "job.h"
 #include "worker.h"
 #include "cache.h"
@@ -91,11 +92,7 @@ static pthread_mutex_t job_mutex = CMUS_MUTEX_INITIALIZER;
 
 void job_init(void)
 {
-	int fds[] = { 0, 0 };
-	int rc = pipe(fds);
-	BUG_ON(rc);
-	job_fd = fds[0];
-	job_fd_priv = fds[1];
+	init_pipes(&job_fd, &job_fd_priv);
 
 	worker_init();
 }
@@ -588,8 +585,11 @@ static void job_handle_result(struct job_result *res)
 	free(res);
 }
 
-void job_handle_results(void)
+void job_handle(void)
 {
+	char buf[128];
+	read(job_fd, buf, sizeof(buf));
+
 	struct job_result *res;
 	while ((res = job_pop_result()))
 		job_handle_result(res);

--- a/job.h
+++ b/job.h
@@ -49,6 +49,6 @@ void job_exit(void);
 void job_schedule_add(int type, struct add_data *data);
 void job_schedule_update(struct update_data *data);
 void job_schedule_update_cache(int type, struct update_cache_data *data);
-void job_handle_results(void);
+void job_handle(void);
 
 #endif

--- a/job.h
+++ b/job.h
@@ -19,7 +19,10 @@
 #ifndef CMUS_JOB_H
 #define CMUS_JOB_H
 
+#include <stdbool.h>
+
 #include "cmus.h"
+#include "worker.h"
 
 struct add_data {
 	enum file_type type;
@@ -39,11 +42,13 @@ struct update_cache_data {
 	unsigned int force : 1;
 };
 
-void do_add_job(void *data);
-void free_add_job(void *data);
-void do_update_job(void *data);
-void free_update_job(void *data);
-void do_update_cache_job(void *data);
-void free_update_cache_job(void *data);
+extern int job_fd;
+
+void job_init(void);
+void job_exit(void);
+void job_schedule_add(int type, struct add_data *data);
+void job_schedule_update(struct update_data *data);
+void job_schedule_update_cache(int type, struct update_cache_data *data);
+void job_handle_results(void);
 
 #endif

--- a/keys.c
+++ b/keys.c
@@ -755,9 +755,7 @@ static const struct key *normal_mode_mouse_handle(MEVENT* event)
 void normal_mode_mouse(MEVENT *event)
 {
 	enum key_context c = view_to_context[cur_view];
-	editable_lock();
 	const struct key *k = normal_mode_mouse_handle(event);
-	editable_unlock();
 
 	if (k == NULL)
 		return;

--- a/locking.c
+++ b/locking.c
@@ -36,20 +36,3 @@ void cmus_mutex_unlock(pthread_mutex_t *mutex)
 	if (unlikely(rc))
 		BUG("error unlocking mutex: %s\n", strerror(rc));
 }
-
-void cmus_mutex_init_recursive(pthread_mutex_t *mutex)
-{
-	pthread_mutexattr_t attr;
-	int rc = pthread_mutexattr_init(&attr);
-	if (rc)
-		goto err;
-	rc = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
-	if (rc)
-		goto err;
-	rc = pthread_mutex_init(mutex, &attr);
-	if (rc)
-		goto err;
-	return;
-err:
-	BUG("error initializing recursive mutex: %s\n", strerror(rc));
-}

--- a/locking.c
+++ b/locking.c
@@ -21,6 +21,8 @@
 
 #include <string.h>
 
+pthread_t main_thread;
+
 void cmus_mutex_lock(pthread_mutex_t *mutex)
 {
 	int rc = pthread_mutex_lock(mutex);

--- a/locking.h
+++ b/locking.h
@@ -28,6 +28,5 @@ extern pthread_t main_thread;
 
 void cmus_mutex_lock(pthread_mutex_t *mutex);
 void cmus_mutex_unlock(pthread_mutex_t *mutex);
-void cmus_mutex_init_recursive(pthread_mutex_t *mutex);
 
 #endif

--- a/locking.h
+++ b/locking.h
@@ -21,6 +21,8 @@
 
 #include <pthread.h>
 
+extern pthread_t main_thread;
+
 #define CMUS_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
 #define CMUS_COND_INITIALIZER PTHREAD_COND_INITIALIZER
 

--- a/options.c
+++ b/options.c
@@ -1765,14 +1765,12 @@ void resume_exit(void)
 		return;
 	}
 
-	player_info_lock();
 	fprintf(f, "status %s\n", player_status_names[player_info.status]);
 	ti = player_info.ti;
 	if (ti) {
 		fprintf(f, "file %s\n", escape(ti->filename));
 		fprintf(f, "position %d\n", player_info.pos);
 	}
-	player_info_unlock();
 	if (lib_cur_track)
 		ti = tree_track_info(lib_cur_track);
 	else

--- a/options.c
+++ b/options.c
@@ -471,9 +471,7 @@ static void set_lib_sort(unsigned int id, const char *buf)
 	sort_key_t *keys = parse_sort_keys(buf);
 
 	if (keys) {
-		editable_lock();
 		editable_set_sort_keys(&lib_editable, keys);
-		editable_unlock();
 		sort_keys_to_str(keys, lib_editable.sort_str, sizeof(lib_editable.sort_str));
 	}
 }
@@ -488,9 +486,7 @@ static void set_pl_sort(unsigned int id, const char *buf)
 	sort_key_t *keys = parse_sort_keys(buf);
 
 	if (keys) {
-		editable_lock();
 		editable_set_sort_keys(&pl_editable, keys);
-		editable_unlock();
 		sort_keys_to_str(keys, pl_editable.sort_str, sizeof(pl_editable.sort_str));
 	}
 }
@@ -725,16 +721,13 @@ static void set_play_sorted(unsigned int id, const char *buf)
 	if (!parse_bool(buf, &tmp))
 		return;
 
-	editable_lock();
 	play_sorted = tmp;
-	editable_unlock();
 
 	update_statusline();
 }
 
 static void toggle_play_sorted(unsigned int id)
 {
-	editable_lock();
 	play_sorted = play_sorted ^ 1;
 
 	/* shuffle would override play_sorted... */
@@ -744,7 +737,6 @@ static void toggle_play_sorted(unsigned int id)
 		shuffle = 0;
 	}
 
-	editable_unlock();
 	update_statusline();
 }
 
@@ -804,14 +796,11 @@ static void set_aaa_mode(unsigned int id, const char *buf)
 
 static void toggle_aaa_mode(unsigned int id)
 {
-	editable_lock();
-
 	/* aaa mode makes no sense in playlist */
 	play_library = 1;
 
 	aaa_mode++;
 	aaa_mode %= 3;
-	editable_unlock();
 	update_statusline();
 }
 
@@ -1726,7 +1715,6 @@ void resume_load(void)
 		ti = old = cache_get_ti(resume.lib_filename, 0);
 		cache_unlock();
 		if (ti) {
-			editable_lock();
 			lib_add_track(ti);
 			track_info_unref(ti);
 			lib_store_cur_track(ti);
@@ -1738,7 +1726,6 @@ void resume_load(void)
 				tree_sel_current(auto_expand_albums_follow);
 				sorted_sel_current();
 			}
-			editable_unlock();
 		}
 		free(resume.lib_filename);
 	}
@@ -1754,9 +1741,7 @@ void resume_load(void)
 		free(resume.filename);
 	}
 	if (resume.live_filter) {
-		editable_lock();
 		filters_set_live(resume.live_filter);
-		editable_unlock();
 		free(resume.live_filter);
 	}
 	if (resume.browser_dir) {

--- a/player.h
+++ b/player.h
@@ -50,13 +50,8 @@ enum replaygain {
 };
 
 struct player_info {
-	pthread_mutex_t mutex;
-
 	/* current track */
 	struct track_info *ti;
-
-	/* stream metadata */
-	char metadata[255 * 16 + 1];
 
 	/* status */
 	enum player_status status;
@@ -77,6 +72,7 @@ struct player_info {
 };
 
 extern int player_fd;
+extern char player_metadata[255 * 16 + 1];
 extern struct player_info player_info;
 extern int player_cont;
 extern int player_repeat_current;
@@ -107,6 +103,7 @@ void player_seek(double offset, int relative, int start_playing);
 void player_set_op(const char *name);
 void player_set_buffer_chunks(unsigned int nr_chunks);
 int player_get_buffer_chunks(void);
+void player_info_snapshot(void);
 
 void player_set_soft_volume(int l, int r);
 void player_set_soft_vol(int soft);
@@ -120,7 +117,7 @@ void player_handle(void);
 #define VF_PERCENTAGE	0x02
 int player_set_vol(int l, int lf, int r, int rf);
 
-#define player_info_lock() cmus_mutex_lock(&player_info.mutex)
-#define player_info_unlock() cmus_mutex_unlock(&player_info.mutex)
+void player_metadata_lock(void);
+void player_metadata_unlock(void);
 
 #endif

--- a/player.h
+++ b/player.h
@@ -49,10 +49,6 @@ enum replaygain {
 	RG_ALBUM_PREFERRED
 };
 
-struct player_callbacks {
-	int (*get_next)(struct track_info **ti);
-};
-
 struct player_info {
 	pthread_mutex_t mutex;
 
@@ -80,6 +76,7 @@ struct player_info {
 	unsigned int buffer_fill_changed : 1;
 };
 
+extern int player_fd;
 extern struct player_info player_info;
 extern int player_cont;
 extern int player_repeat_current;
@@ -90,7 +87,7 @@ extern int soft_vol;
 extern int soft_vol_l;
 extern int soft_vol_r;
 
-void player_init(const struct player_callbacks *callbacks);
+void player_init(void);
 void player_exit(void);
 
 /* set current file */
@@ -116,6 +113,8 @@ void player_set_soft_vol(int soft);
 void player_set_rg(enum replaygain rg);
 void player_set_rg_limit(int limit);
 void player_set_rg_preamp(double db);
+
+void player_handle(void);
 
 #define VF_RELATIVE	0x01
 #define VF_PERCENTAGE	0x02

--- a/search.c
+++ b/search.c
@@ -29,16 +29,6 @@ struct searchable {
 	struct searchable_ops ops;
 };
 
-static void search_lock(void)
-{
-	editable_lock();
-}
-
-static void search_unlock(void)
-{
-	editable_unlock();
-}
-
 static int advance(struct searchable *s, struct iter *iter,
 		enum search_direction dir, int *wrapped)
 {
@@ -126,7 +116,6 @@ int search(struct searchable *s, const char *text, enum search_direction dir, in
 	struct iter iter;
 	int ret;
 
-	search_lock();
 	if (beginning) {
 		/* first or last item */
 		iter = s->head;
@@ -141,7 +130,6 @@ int search(struct searchable *s, const char *text, enum search_direction dir, in
 	}
 	if (ret)
 		ret = do_search(s, &iter, text, dir, 0);
-	search_unlock();
 	return ret;
 }
 
@@ -150,12 +138,9 @@ int search_next(struct searchable *s, const char *text, enum search_direction di
 	struct iter iter;
 	int ret;
 
-	search_lock();
 	if (!s->ops.get_current(s->data, &iter)) {
-		search_unlock();
 		return 0;
 	}
 	ret = do_search(s, &iter, text, dir, 1);
-	search_unlock();
 	return ret;
 }

--- a/server.c
+++ b/server.c
@@ -88,7 +88,6 @@ static int cmd_status(struct client *client)
 	int i, ret;
 	enum player_status status;
 
-	player_info_lock();
 	gbuf_addf(&buf, "status %s\n", player_status_names[player_info.status]);
 	ti = player_info.ti;
 	if (ti) {
@@ -141,7 +140,6 @@ static int cmd_status(struct client *client)
 	gbuf_addf(&buf, "set vol_right %d\n", vol_right);
 
 	gbuf_add_str(&buf, "\n");
-	player_info_unlock();
 
 	ret = write_all(client->fd, buf.buffer, buf.len);
 	gbuf_free(&buf);
@@ -168,7 +166,6 @@ static int cmd_format_print(struct client *client, char *arg)
 
 	GBUF(buf);
 
-	player_info_lock();
 	const struct format_option *fopts = get_global_fopts();
 	for (i = 0; i < ac; ++i) {
 		if (format_valid(args[i], fopts))
@@ -177,7 +174,6 @@ static int cmd_format_print(struct client *client, char *arg)
 		free(args[i]);
 	}
 	gbuf_add_ch(&buf, '\n');
-	player_info_unlock();
 
 	ret = write_all(client->fd, buf.buffer, buf.len);
 	gbuf_free(&buf);

--- a/track_info.c
+++ b/track_info.c
@@ -121,13 +121,6 @@ void track_info_unref(struct track_info *ti)
 		track_info_free(ti);
 }
 
-void track_info_unrefp(struct track_info **ti)
-{
-	if (*ti)
-		track_info_unref(*ti);
-	*ti = NULL;
-}
-
 int track_info_has_tag(const struct track_info *ti)
 {
 	return ti->artist || ti->album || ti->title;

--- a/track_info.h
+++ b/track_info.h
@@ -130,7 +130,6 @@ void track_info_set_comments(struct track_info *ti, struct keyval *comments);
 
 void track_info_ref(struct track_info *ti);
 void track_info_unref(struct track_info *ti);
-void track_info_unrefp(struct track_info **ti);
 
 /*
  * returns: 1 if @ti has any of the following tags: artist, album, title

--- a/ui_curses.h
+++ b/ui_curses.h
@@ -48,7 +48,6 @@ extern char *play_queue_ext_filename;
 extern char *charset;
 extern int using_utf8;
 
-void ui_curses_notify(void);
 void update_titleline(void);
 void update_statusline(void);
 void update_filterline(void);

--- a/utils.h
+++ b/utils.h
@@ -24,6 +24,7 @@
 #endif
 
 #include "compiler.h"
+#include "debug.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -263,6 +264,18 @@ static inline void enable_stdio(void)
 	while (dup2(_saved_stderr, 2) == -1 && errno == EINTR) { }
 	close(_saved_stdout);
 	close(_saved_stderr);
+}
+
+static inline void init_pipes(int *out, int *in)
+{
+	int fds[2];
+	int rc = pipe(fds);
+	BUG_ON(rc);
+	*out = fds[0];
+	*in = fds[1];
+	int flags = fcntl(*out, F_GETFL);
+	rc = fcntl(*out, F_SETFL, flags | O_NONBLOCK);
+	BUG_ON(rc);
 }
 
 #endif

--- a/utils.h
+++ b/utils.h
@@ -54,8 +54,6 @@
 #define STATIC_ASSERT(cond) \
 	static uint8_t CONCATENATE(_cmus_unused_, __LINE__)[2*(cond) - 1] UNUSED
 
-#define CLEANUP(f) __attribute__((cleanup(f)))
-
 static inline int min(int a, int b)
 {
 	return a < b ? a : b;


### PR DESCRIPTION
This PR removes the player_info_lock function. With this change and #472 (which needs to be merged first) almost all cross-file locking has been removed.

This is done as follows:

- The metadata array (4kb) has been moved out of the player_info structure. It is only used in one place and still requires separate locking for each access.
- The player.c file operates exclusively on a new symbol called player_info_priv.
- At the start of each main-loop iteration, the main thread requests a snapshot of the player_info_priv object. This snapshot is then stored in player_info which is owned by the main thread.
- The main thread can then access this symbol without locking.