### PR TITLE
Support 24-bit/32-bit encodings in sndio output plugin

### DIFF
--- a/configure
+++ b/configure
@@ -21,7 +21,7 @@ check_cflags()
 check_sndio()
 {
 	case `uname -s` in
-	OpenBSD)
+	OpenBSD|FreeBSD)
 		check_library SNDIO "" "-lsndio"
 		return $?
 	esac

--- a/sndio.c
+++ b/sndio.c
@@ -20,7 +20,6 @@
 
 #include <sys/types.h>
 #include <sys/ioctl.h>
-#include <sys/audioio.h>
 #include <sys/stat.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -82,6 +81,12 @@ static int sndio_set_sf(sample_format_t sf)
 		par.le = 1;
 
 	switch (sf_get_bits(sndio_sf)) {
+	case 32:
+		par.bits = 32;
+		break;
+	case 24:
+		par.bits = 24;
+		break;
 	case 16:
 		par.bits = 16;
 		break;


### PR DESCRIPTION
I was trying to play a 24-bit encoded FLAC file in cmus using the sndio output plugin, which failed with an error message saying that it's unsupported.  With just a little bit of extra code it works.

I also removed `sys/audioio.h` which is not needed to compile cmus on OpenBSD 5.9 and does not exist on FreeBSD.

While here I also enabled checking for sndio on FreeBSD in the configure script.