### PR TITLE
Add lib_add_filter option

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -991,6 +991,9 @@ icecast_default_charset (ISO-8859-1)
 
 	NOTE:  This is used only if the metadata is not valid UTF-8.
 
+lib_add_filter (`Filter`)
+	Apply filter when adding to library view. See *FILTERS*.
+
 lib_sort (artist album discnumber tracknumber title filename) [`Sort Keys`]
 	Sort keys for the sorted library view (2).
 

--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -992,7 +992,7 @@ icecast_default_charset (ISO-8859-1)
 	NOTE:  This is used only if the metadata is not valid UTF-8.
 
 lib_add_filter (`Filter`)
-	Apply filter when adding to library view. See *FILTERS*.
+	Apply filter when adding files to the library. See *FILTERS*.
 
 lib_sort (artist album discnumber tracknumber title filename) [`Sort Keys`]
 	Sort keys for the sorted library view (2).

--- a/lib.c
+++ b/lib.c
@@ -40,6 +40,7 @@ char *lib_live_filter = NULL;
 
 struct rb_root lib_shuffle_root;
 static struct expr *filter = NULL;
+static struct expr *add_filter = NULL;
 static int remove_from_hash = 1;
 
 static struct expr *live_filter_expr = NULL;
@@ -160,10 +161,16 @@ static int is_filtered(struct track_info *ti)
 
 void lib_add_track(struct track_info *ti, void *opaque)
 {
+	if (add_filter && !expr_eval(add_filter, ti)) {
+		/* filter any files exluded by lib_add_filter */
+		return;
+	}
+
 	if (!hash_insert(ti)) {
 		/* duplicate files not allowed */
 		return;
 	}
+
 	if (!is_filtered(ti))
 		views_add_track(ti);
 }
@@ -504,6 +511,14 @@ void lib_set_filter(struct expr *expr)
 	filter = expr;
 	do_lib_filter(clear_before);
 }
+
+void lib_set_add_filter(struct expr *expr)
+{
+	if (add_filter)
+		expr_free(add_filter);
+	add_filter = expr;
+}
+
 
 static struct tree_track *get_sel_track(void)
 {

--- a/lib.h
+++ b/lib.h
@@ -113,6 +113,7 @@ struct track_info *lib_goto_prev(void);
 void lib_add_track(struct track_info *track_info, void *opaque);
 void lib_set_filter(struct expr *expr);
 void lib_set_live_filter(const char *str);
+void lib_set_add_filter(struct expr *expr);
 int lib_remove(struct track_info *ti);
 void lib_clear_store(void);
 void lib_reshuffle(void);

--- a/options.c
+++ b/options.c
@@ -1100,8 +1100,7 @@ static void set_lib_add_filter(void *data, const char *buf)
 	if (lib_add_filter != NULL)
 		free(lib_add_filter);
 
-	lib_add_filter = malloc(strlen(buf) + 1);
-	strcpy(lib_add_filter, buf);
+	lib_add_filter = xstrdup(buf);
 
 	lib_set_add_filter(expr);
 }

--- a/options.c
+++ b/options.c
@@ -143,6 +143,7 @@ char *window_title_format = NULL;
 char *window_title_alt_format = NULL;
 char *id3_default_charset = NULL;
 char *icecast_default_charset = NULL;
+char *lib_add_filter = NULL;
 
 static void buf_int(char *buf, int val, size_t size)
 {
@@ -1079,6 +1080,32 @@ static void toggle_mpris(void *data)
 	mpris ^= 1;
 }
 
+static void get_lib_add_filter(void *data, char *buf)
+{
+	strcpy(buf, lib_add_filter ? lib_add_filter : "");
+}
+
+static void set_lib_add_filter(void *data, const char *buf)
+{
+	struct expr *expr = NULL;
+
+	if (strlen(buf)) {
+		/* parse expression if non-empty string given */
+		expr = expr_parse(buf);
+
+		if (!expr)
+			return;
+	}
+
+	if (lib_add_filter != NULL)
+		free(lib_add_filter);
+
+	lib_add_filter = malloc(strlen(buf) + 1);
+	strcpy(lib_add_filter, buf);
+
+	lib_set_add_filter(expr);
+}
+
 /* }}} */
 
 /* special callbacks (id set) {{{ */
@@ -1298,6 +1325,7 @@ static const struct {
 	DT(skip_track_info)
 	DT(mouse)
 	DT(mpris)
+	DN(lib_add_filter)
 	{ NULL, NULL, NULL, NULL, 0 }
 };
 


### PR DESCRIPTION
This patch allows for a filter to be applied when adding files to the library view. An example use-case would be music libraries with multiple formats, or those with cue files resulting in files being added twice.

I'm open to any feedback on the structure of the change; in particular I think my {get,set}_lib_add_filter functions are a bit logic heavy for where they are in the code base.