### PR TITLE
play_mode refactor

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -1012,6 +1012,10 @@ pl_sort () [`Sort Keys`]
 	Sort keys for the playlist view (3).  Empty value disables sorting and
 	enables manually moving tracks.
 
+play_library (true)
+	Play tracks from the library instead of playlist. This setting changes
+	*play_mode* and is kept for backwards compatability.
+
 play_mode (library playlist)
 	Play tracks from the library or from the playlist.
 

--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -171,11 +171,11 @@ Right hand side of the status line (second row from the bottom, black text on
 a grey background) consists of the following fields:
 
 @pre
-aaa_mode & play_sorted & play_library | continue follow repeat shuffle
+aaa_mode & play_sorted & play_mode=library | continue follow repeat shuffle
 @endpre
 
-NOTE: *aaa_mode* and *play_sorted* will be displayed only if *play_library* is
-*true* because these are meaningless when playing the playlists (view 3).
+NOTE: *aaa_mode* and *play_sorted* will be displayed only if *play_mode* is
+*library* because these are meaningless when playing the playlists (view 3).
 
 Pressing *m*, *o*, *M*, *C*, *r* and *s* keys should make it easier to
 understand what all those fields mean.
@@ -208,7 +208,7 @@ l, right                    seek +5
 h, left                     seek -5
 m                           toggle aaa_mode
 C                           toggle continue
-M                           toggle play_library
+M                           toggle play_mode
 o                           toggle play_sorted
 r                           toggle repeat
 ^R                          toggle repeat_current
@@ -1012,12 +1012,12 @@ pl_sort () [`Sort Keys`]
 	Sort keys for the playlist view (3).  Empty value disables sorting and
 	enables manually moving tracks.
 
-play_library (true)
-	Play tracks from the library instead of playlist.
+play_mode (library playlist)
+	Play tracks from the library or from the playlist.
 
 play_sorted (false)
 	Play tracks from the library in the sorted view (2) order instead of
-	tree view (1) order.  Used only when play_library is true.
+	tree view (1) order.  Used only when *play_mode* is *library*.
 
 repeat (false)
 	Repeat after all tracks played.

--- a/cmus.c
+++ b/cmus.c
@@ -87,7 +87,7 @@ void cmus_prev(void)
 {
 	struct track_info *info;
 
-	if (play_library) {
+	if (play_mode == PLAY_LIBRARY) {
 		info = lib_goto_prev();
 	} else {
 		info = pl_goto_prev();
@@ -392,7 +392,7 @@ static struct track_info *cmus_get_next_from_main_thread(void)
 {
 	struct track_info *ti = play_queue_remove();
 	if (!ti)
-		ti = play_library ? lib_goto_next() : pl_goto_next();
+		ti = (play_mode == PLAY_LIBRARY) ? lib_goto_next() : pl_goto_next();
 	return ti;
 }
 

--- a/cmus.c
+++ b/cmus.c
@@ -50,6 +50,16 @@
 /* save_playlist_cb, save_ext_playlist_cb */
 typedef int (*save_tracks_cb)(void *data, struct track_info *ti);
 
+/* cmus_next, cmus_prev */
+typedef struct track_info *(*goto_next_prev)(void);
+static const struct {
+	const goto_next_prev goto_next;
+	const goto_next_prev goto_prev;
+} play_mode_controls[] = {
+	[PLAY_LIBRARY]  	= { lib_goto_next, lib_goto_prev },
+	[PLAY_PLAYLIST]		= { pl_goto_next, pl_goto_prev }
+};
+
 static char **playable_exts;
 static const char * const playlist_exts[] = { "m3u", "pl", "pls", NULL };
 
@@ -87,11 +97,7 @@ void cmus_prev(void)
 {
 	struct track_info *info;
 
-	if (play_mode == PLAY_LIBRARY) {
-		info = lib_goto_prev();
-	} else {
-		info = pl_goto_prev();
-	}
+	info = play_mode_controls[play_mode].goto_prev();
 
 	if (info)
 		player_set_file(info);
@@ -392,7 +398,7 @@ static struct track_info *cmus_get_next_from_main_thread(void)
 {
 	struct track_info *ti = play_queue_remove();
 	if (!ti)
-		ti = (play_mode == PLAY_LIBRARY) ? lib_goto_next() : pl_goto_next();
+		ti = play_mode_controls[play_mode].goto_next();
 	return ti;
 }
 

--- a/command_mode.c
+++ b/command_mode.c
@@ -1550,9 +1550,9 @@ static void cmd_win_activate(char *arg)
 			shuffle_insert(shuffle_root, previous, next);
 		/* update lib/pl mode */
 		if (cur_view < 2)
-			play_library = 1;
+			play_mode = PLAY_LIBRARY;
 		if (cur_view == 2)
-			play_library = 0;
+			play_mode = PLAY_PLAYLIST;
 
 		player_play_file(info);
 	}

--- a/data/rc
+++ b/data/rc
@@ -25,7 +25,7 @@ bind common F push filter
 bind common G win-bottom
 bind common I echo {}
 bind common L push live-filter 
-bind common M toggle play_library
+bind common M toggle play_mode
 bind common N search-prev
 bind common P win-mv-before
 bind common [ vol +1% +0

--- a/options.c
+++ b/options.c
@@ -69,7 +69,7 @@ int show_playback_position = 1;
 int show_remaining_time = 0;
 int set_term_title = 1;
 int wrap_search = 1;
-int play_library = PLAY_LIBRARY;
+int play_mode = PLAY_LIBRARY;
 int repeat = 0;
 int shuffle = 0;
 int follow = 0;
@@ -230,7 +230,7 @@ static const struct {
 		"%{?stream?buf: %{buffer} }"
 		"%{?show_current_bitrate & bitrate>=0? %{bitrate} kbps }"
 		"%="
-		"%{?repeat_current?repeat current?%{?play_library?%{playlist_mode} from %{?play_sorted?sorted }library?playlist}}"
+		"%{?repeat_current?repeat current?%{?play_mode=\"library\"?%{playlist_mode} from %{?play_sorted?sorted }library?playlist}}"
 		" | %1{continue}%1{follow}%1{repeat}%1{shuffle} "
 	},
 	[FMT_PLAYLIST_ALT]	= { "altformat_playlist"	, " %f%= %d "						},
@@ -560,26 +560,26 @@ const char * const play_mode_names[NR_PLAY_MODES + 1] = {
 	"playlist", "library", NULL
 };
 
-static void get_play_library(void *data, char *buf)
+static void get_play_mode(void *data, char *buf)
 {
-	strcpy(buf, play_mode_names[play_library]);
+	strcpy(buf, play_mode_names[play_mode]);
 }
 
-static void set_play_library(void *data, const char *buf)
+static void set_play_mode(void *data, const char *buf)
 {
 	int tmp;
 
 	if (!parse_enum(buf, 0, NR_PLAY_MODES - 1, play_mode_names, &tmp))
 		return;
 
-	play_library = tmp;
+	play_mode = tmp;
 
 	update_statusline();
 }
 
-static void toggle_play_library(void *data)
+static void toggle_play_mode(void *data)
 {
-	play_library = (play_library + 1) % NR_PLAY_MODES;
+	play_mode = (play_mode + 1) % NR_PLAY_MODES;
 	update_statusline();
 }
 
@@ -607,7 +607,7 @@ static void toggle_play_sorted(void *data)
 	/* shuffle would override play_sorted... */
 	if (play_sorted) {
 		/* play_sorted makes no sense in playlist */
-		play_library = 1;
+		play_mode = PLAY_LIBRARY;
 		shuffle = 0;
 	}
 
@@ -671,7 +671,7 @@ static void set_aaa_mode(void *data, const char *buf)
 static void toggle_aaa_mode(void *data)
 {
 	/* aaa mode makes no sense in playlist */
-	play_library = 1;
+	play_mode = PLAY_LIBRARY;
 
 	aaa_mode++;
 	aaa_mode %= 3;
@@ -1274,7 +1274,7 @@ static const struct {
 	DN(output_plugin)
 	DN(passwd)
 	DN(pl_sort)
-	DT(play_library)
+	DT(play_mode)
 	DT(play_sorted)
 	DT(display_artist_sort_name)
 	DT(repeat)

--- a/options.c
+++ b/options.c
@@ -557,7 +557,7 @@ const char * const view_names[NR_VIEWS + 1] = {
 };
 
 const char * const play_mode_names[NR_PLAY_MODES + 1] = {
-	"playlist", "library", NULL
+	"library", "playlist", NULL
 };
 
 static void get_play_mode(void *data, char *buf)
@@ -580,6 +580,28 @@ static void set_play_mode(void *data, const char *buf)
 static void toggle_play_mode(void *data)
 {
 	play_mode = (play_mode + 1) % NR_PLAY_MODES;
+	update_statusline();
+}
+
+static void get_play_library(void *data, char *buf)
+{
+	strcpy(buf, bool_names[play_mode == PLAY_LIBRARY]);
+}
+
+static void set_play_library(void *data, const char *buf)
+{
+	int play_library;
+	if (!parse_bool(buf, &play_library))
+		return;
+
+	play_mode = play_library ? PLAY_LIBRARY : PLAY_PLAYLIST;
+
+	update_statusline();
+}
+
+static void toggle_play_library(void *data)
+{
+	play_mode = play_mode == PLAY_LIBRARY ? PLAY_PLAYLIST : PLAY_LIBRARY;
 	update_statusline();
 }
 
@@ -1274,6 +1296,7 @@ static const struct {
 	DN(output_plugin)
 	DN(passwd)
 	DN(pl_sort)
+	DT(play_library)
 	DT(play_mode)
 	DT(play_sorted)
 	DT(display_artist_sort_name)

--- a/options.c
+++ b/options.c
@@ -69,7 +69,7 @@ int show_playback_position = 1;
 int show_remaining_time = 0;
 int set_term_title = 1;
 int wrap_search = 1;
-int play_library = 1;
+int play_library = PLAY_LIBRARY;
 int repeat = 0;
 int shuffle = 0;
 int follow = 0;
@@ -556,21 +556,30 @@ const char * const view_names[NR_VIEWS + 1] = {
 	"tree", "sorted", "playlist", "queue", "browser", "filters", "settings", NULL
 };
 
+const char * const play_mode_names[NR_PLAY_MODES + 1] = {
+	"playlist", "library", NULL
+};
+
 static void get_play_library(void *data, char *buf)
 {
-	strcpy(buf, bool_names[play_library]);
+	strcpy(buf, play_mode_names[play_library]);
 }
 
 static void set_play_library(void *data, const char *buf)
 {
-	if (!parse_bool(buf, &play_library))
+	int tmp;
+
+	if (!parse_enum(buf, 0, NR_PLAY_MODES - 1, play_mode_names, &tmp))
 		return;
+
+	play_library = tmp;
+
 	update_statusline();
 }
 
 static void toggle_play_library(void *data)
 {
-	play_library ^= 1;
+	play_library = (play_library + 1) % NR_PLAY_MODES;
 	update_statusline();
 }
 

--- a/options.h
+++ b/options.h
@@ -66,8 +66,8 @@ enum {
 };
 
 enum {
-	PLAY_PLAYLIST,
 	PLAY_LIBRARY,
+	PLAY_PLAYLIST,
 	NR_PLAY_MODES
 };
 
@@ -136,7 +136,7 @@ extern int show_playback_position;
 extern int show_remaining_time;
 extern int set_term_title;
 extern int wrap_search;
-extern int play_library;
+extern int play_mode;
 extern int repeat;
 extern int shuffle;
 extern int follow;

--- a/options.h
+++ b/options.h
@@ -66,6 +66,12 @@ enum {
 };
 
 enum {
+	PLAY_PLAYLIST,
+	PLAY_LIBRARY,
+	NR_PLAY_MODES
+};
+
+enum {
 	COLOR_CMDLINE_BG,
 	COLOR_CMDLINE_FG,
 	COLOR_ERROR,

--- a/server.c
+++ b/server.c
@@ -69,6 +69,7 @@ static int cmd_status(struct client *client)
 	const char *export_options[] = {
 		"aaa_mode",
 		"continue",
+		"play_library",
 		"play_mode",
 		"play_sorted",
 		"replaygain",

--- a/server.c
+++ b/server.c
@@ -69,7 +69,7 @@ static int cmd_status(struct client *client)
 	const char *export_options[] = {
 		"aaa_mode",
 		"continue",
-		"play_library",
+		"play_mode",
 		"play_sorted",
 		"replaygain",
 		"replaygain_limit",

--- a/ui_curses.c
+++ b/ui_curses.c
@@ -644,7 +644,7 @@ const struct format_option *get_global_fopts(void)
 	int buffer_fill, vol, vol_left, vol_right;
 	int duration = -1;
 
-	fopt_set_time(&track_fopts[TF_TOTAL], play_library ? lib_editable.total_time :
+	fopt_set_time(&track_fopts[TF_TOTAL], (play_mode == PLAY_LIBRARY) ? lib_editable.total_time :
 			pl_playing_total_time(), 0);
 
 	fopt_set_str(&track_fopts[TF_FOLLOW], follow_strs[follow]);
@@ -1966,7 +1966,7 @@ static void update(void)
 	}
 
 	/* total time changed? */
-	if (play_library) {
+	if (play_mode == PLAY_LIBRARY) {
 		needs_status_update += lib_editable.shared->win->changed;
 		lib_editable.shared->win->changed = 0;
 	} else {


### PR DESCRIPTION
These patches refactor the _play_library_ option to a new _play_mode_ enumeration. 

This removes the limitation on the number play modes, due to the boolean nature of _play_library_, and allows for the addition of future play modes such as those requested in #467.

The options exposed by the server component have been changed by these patches. Is this an issue?
