### PR TITLE
Make filepath affect album separation.

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -796,6 +796,8 @@ album_path_ignore_re [`Extended Regexp`]
 	Regexp to use when separate_albums_by_path is on.
 	Any directories it matches (entirely) in a track filename
 	are excluded from pathname comparison.
+	Usability note: the [^...]* construct should not be used,
+	as it does not work with either POSIX or glibc.
 
 altformat_current [`Format String`]
 	Alternative format string for the line displaying currently playing

--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -794,8 +794,8 @@ aaa_mode (all) [all, artist, album]
 
 album_path_ignore_re [`Extended Regexp`]
 	Regexp to use when separate_albums_by_path is on.
-	Any directories it matches (entirely) in a track filename
-	are excluded from pathname comparison.
+	Any matches in track filename, followed by a slash,
+	are 'eaten' prior to pathname comparison.
 	Usability note: the [^...]* construct should not be used,
 	as it does not work with either POSIX or glibc.
 

--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -792,6 +792,11 @@ aaa_mode (all) [all, artist, album]
 	like there were only the files of the currently playing artist in the
 	library.
 
+album_path_ignore_re [`Extended Regexp`]
+	Regexp to use when separate_albums_by_path is on.
+	Any directories it matches (entirely) in a track filename
+	are excluded from pathname comparison.
+
 altformat_current [`Format String`]
 	Alternative format string for the line displaying currently playing
 	track.
@@ -1046,6 +1051,13 @@ rewind_offset (5) [-1-9999]
 	player_prev jumps to the previous track. Otherwise, player_prev jumps
 	to the beginning of the current track. If rewind_offset=-1, player_prev
 	always jumps to the previous track.
+
+separate_albums_by_path (true)
+	Whether to put two tracks sharing the same album name, but being in different
+	directories, each into a dedicated album (to avoid tracks from the
+	directories being next to each other in the Library view).
+	The album_path_ignore_re could be used to tell which components in paths
+	to ignore (i.e. per-CD dirs).
 
 scroll_offset (2) [0-9999]
 	Minimal number of screen lines to keep above and below the cursor.

--- a/lib.h
+++ b/lib.h
@@ -61,6 +61,11 @@ struct album {
 	int date;
 	/* min date of the tracks added to this album */
 	int min_date;
+
+	/* distinguishes albums having the same name,
+	 * but residing in different directories
+	 * <= 0 means undefined */
+	int dup_id;
 };
 
 struct artist {

--- a/options.c
+++ b/options.c
@@ -1284,15 +1284,13 @@ static void set_format(void *data, const char *buf)
 	update_full();
 }
 
-static void print_re_error(int errcode, regex_t *re, const char *re_src) {
-	size_t len;
-	char *buf;
+static void print_re_error(int errcode, regex_t *re, const char *re_src)
+{
+	size_t len = regerror(errcode, re, NULL, 0);
+	char *buf = xmalloc(len+1);
 
-	len = regerror(errcode, re, NULL, 0);
-	buf = xmalloc(len+1);
 	regerror(errcode, re, buf, len+1);
 	fprintf(stderr, "Failed to compile regex '%s': %s\n", re_src, buf);
-	exit(1);
 }
 
 static void get_album_path_ignore_re(void *data, char *buf, size_t size)

--- a/options.c
+++ b/options.c
@@ -1311,8 +1311,10 @@ static void set_album_path_ignore_re(void *data, const char *buf)
 	int rc;
 
 	fprintf(stderr, "HERE %d %p\n", ever_called, patternp);
-	if (ever_called)
+	if (ever_called) {
 		free(*patternp);
+		regfree(&album_path_ignore_re);
+	}
 	fprintf(stderr, "HERE freed\n");
 	*patternp = xstrdup(buf);
 	fprintf(stderr, "HERE '%s' %p\n", *patternp, *patternp);

--- a/options.c
+++ b/options.c
@@ -56,9 +56,9 @@ const char DEFAULT_ALBUM_PATH_IGNORE_RE[] =
 		/* The regexp being intended:
 		 *  "[^[:alnum:]]*([cC][dD]|[dD][iI][sS][cCkK])[^[:alnum:]]*[[:alnum:]]+[^[:alnum:]]*"
 		 * The [^...]* construct, however, does not seem to work with either POSIX or glibc.
+		 * Do a subset of this instead. "([-_]*|.)" at beginning or end also doesn't work.
 		 * */
-		"([cC][dD]|[dD][iI][sS][cCkK])[[:alnum:]]+";
-
+		"([cC][dD]|[dD][iI][sS][cCkK])([-_. \t]*|.)[[:alnum:]]+";
 
 /* initialized option variables */
 

--- a/options.c
+++ b/options.c
@@ -1504,7 +1504,11 @@ void options_add(void)
 		opt = option_find("album_path_ignore_re");
 		opt->data = xmalloc(sizeof(void*));
 		set_album_path_ignore_re(opt->data,
-				"[^[:alnum:]]*\\([cC][dD]|[dD][iI][sS][cCkK]\\)[^[:alnum:]]*[[:alnum:]]\\+[^[:alnum:]]*");
+				/* The regexp being intended:
+				 *  "[^[:alnum:]]*([cC][dD]|[dD][iI][sS][cCkK])[^[:alnum:]]*[[:alnum:]]+[^[:alnum:]]*"
+				 * The [^...]* construct, however, does not seem to work with either POSIX or glibc.
+				 * */
+				"([cC][dD]|[dD][iI][sS][cCkK])[[:alnum:]]+");
 	}
 
 	ip_add_options();

--- a/options.c
+++ b/options.c
@@ -1289,7 +1289,7 @@ static void print_re_error(int errcode, regex_t *re, const char *re_src) {
 	char *buf;
 
 	len = regerror(errcode, re, NULL, 0);
-	buf = malloc(len+1);
+	buf = xmalloc(len+1);
 	regerror(errcode, re, buf, len+1);
 	fprintf(stderr, "Failed to compile regex '%s': %s\n", re_src, buf);
 	exit(1);

--- a/options.c
+++ b/options.c
@@ -1503,7 +1503,8 @@ void options_add(void)
 		struct cmus_opt *opt;
 		opt = option_find("album_path_ignore_re");
 		opt->data = xmalloc(sizeof(void*));
-		set_album_path_ignore_re(opt->data, "cd[0-9]");
+		set_album_path_ignore_re(opt->data,
+				"[^[:alnum:]]*\\([cC][dD]|[dD][iI][sS][cCkK]\\)[^[:alnum:]]*[[:alnum:]]\\+[^[:alnum:]]*");
 	}
 
 	ip_add_options();

--- a/options.c
+++ b/options.c
@@ -82,6 +82,7 @@ int auto_expand_albums_selcur = 1;
 int show_all_tracks = 1;
 int mouse = 0;
 int mpris = 1;
+int separate_albums_by_path = 1;
 
 int colors[NR_COLORS] = {
 	-1,
@@ -1104,6 +1105,21 @@ static void set_lib_add_filter(void *data, const char *buf)
 	lib_set_add_filter(expr);
 }
 
+static void get_separate_albums_by_path(void *data, char *buf, size_t size)
+{
+	strscpy(buf, bool_names[separate_albums_by_path], size);
+}
+
+static void set_separate_albums_by_path(void *data, const char *buf)
+{
+	parse_bool(buf, &separate_albums_by_path);
+}
+
+static void toggle_separate_albums_by_path(void *data)
+{
+	separate_albums_by_path ^= 1;
+}
+
 /* }}} */
 
 /* special callbacks (id set) {{{ */
@@ -1356,6 +1372,7 @@ static const struct {
 	DT(mpris)
 	DN(lib_add_filter)
 	DN(album_path_ignore_re)
+	DT(separate_albums_by_path)
 	{ NULL, NULL, NULL, NULL, 0 }
 };
 
@@ -1406,6 +1423,8 @@ void option_add(const char *name, const void *data, opt_get_cb get,
 {
 	struct cmus_opt *opt = xnew(struct cmus_opt, 1);
 	struct list_head *item;
+
+	fprintf(stderr, "adding %s\n", name);
 
 	opt->name = name;
 	opt->data = (void *)data;
@@ -1547,6 +1566,7 @@ void options_exit(void)
 
 		buf[0] = 0;
 		opt->get(opt->data, buf, OPTION_MAX_SIZE);
+		fprintf(stderr, "saving %s\n", opt->name);
 		fprintf(f, "set %s=%s\n", opt->name, buf);
 	}
 

--- a/options.c
+++ b/options.c
@@ -144,6 +144,7 @@ char *window_title_alt_format = NULL;
 char *id3_default_charset = NULL;
 char *icecast_default_charset = NULL;
 char *lib_add_filter = NULL;
+regex_t album_path_ignore_re;
 
 static void buf_int(char *buf, int val, size_t size)
 {
@@ -1267,6 +1268,37 @@ static void set_format(void *data, const char *buf)
 	update_full();
 }
 
+static void print_re_error(int errcode, regex_t *re, const char *re_src) {
+	size_t len;
+	char *buf;
+
+	len = regerror(errcode, re, NULL, 0);
+	buf = malloc(len+1);
+	regerror(errcode, re, buf, len+1);
+	fprintf(stderr, "Failed to compile regex '%s': %s\n", re_src, buf);
+	exit(1);
+}
+
+static void get_album_path_ignore_re(void *data, char *buf, size_t size)
+{
+	char **patternp = data;
+
+	strscpy(buf, *patternp, size);
+}
+
+static void set_album_path_ignore_re(void *data, const char *buf)
+{
+	int rc;
+	fprintf(stderr, "HERE\n");
+
+	rc = regcomp(&album_path_ignore_re, buf, REG_EXTENDED);
+	if (rc) {
+		print_re_error(rc, &album_path_ignore_re, buf);
+		exit(1);
+	}
+	fprintf(stderr, "HERE\n");
+}
+
 /* }}} */
 
 #define DN(name) { #name, get_ ## name, set_ ## name, NULL, 0 },
@@ -1323,6 +1355,7 @@ static const struct {
 	DT(mouse)
 	DT(mpris)
 	DN(lib_add_filter)
+	DN(album_path_ignore_re)
 	{ NULL, NULL, NULL, NULL, 0 }
 };
 

--- a/options.c
+++ b/options.c
@@ -52,6 +52,14 @@
 #include <curses.h>
 #endif
 
+const char DEFAULT_ALBUM_PATH_IGNORE_RE[] =
+		/* The regexp being intended:
+		 *  "[^[:alnum:]]*([cC][dD]|[dD][iI][sS][cCkK])[^[:alnum:]]*[[:alnum:]]+[^[:alnum:]]*"
+		 * The [^...]* construct, however, does not seem to work with either POSIX or glibc.
+		 * */
+		"([cC][dD]|[dD][iI][sS][cCkK])[[:alnum:]]+";
+
+
 /* initialized option variables */
 
 char *cdda_device = NULL;
@@ -1501,12 +1509,7 @@ void options_add(void)
 		struct cmus_opt *opt;
 		opt = option_find("album_path_ignore_re");
 		opt->data = xmalloc(sizeof(void*));
-		set_album_path_ignore_re(opt->data,
-				/* The regexp being intended:
-				 *  "[^[:alnum:]]*([cC][dD]|[dD][iI][sS][cCkK])[^[:alnum:]]*[[:alnum:]]+[^[:alnum:]]*"
-				 * The [^...]* construct, however, does not seem to work with either POSIX or glibc.
-				 * */
-				"([cC][dD]|[dD][iI][sS][cCkK])[[:alnum:]]+");
+		set_album_path_ignore_re(opt->data, DEFAULT_ALBUM_PATH_IGNORE_RE);
 	}
 
 	ip_add_options();

--- a/options.c
+++ b/options.c
@@ -1299,8 +1299,6 @@ static void get_album_path_ignore_re(void *data, char *buf, size_t size)
 {
 	char **pattern = data;
 
-	fprintf(stderr, "HERE_get %p\n", pattern);
-	fprintf(stderr, "HERE_get '%s'\n", *pattern);
 	strscpy(buf, *pattern, size);
 }
 
@@ -1310,21 +1308,17 @@ static void set_album_path_ignore_re(void *data, const char *buf)
 	char **patternp = data;
 	int rc;
 
-	fprintf(stderr, "HERE %d %p\n", ever_called, patternp);
 	if (ever_called) {
 		free(*patternp);
 		regfree(&album_path_ignore_re);
 	}
-	fprintf(stderr, "HERE freed\n");
 	*patternp = xstrdup(buf);
-	fprintf(stderr, "HERE '%s' %p\n", *patternp, *patternp);
 
 	rc = regcomp(&album_path_ignore_re, buf, REG_EXTENDED);
 	if (rc) {
 		print_re_error(rc, &album_path_ignore_re, buf);
 		exit(1);
 	}
-	fprintf(stderr, "HERE\n");
 	ever_called = 1;
 }
 
@@ -1436,8 +1430,6 @@ void option_add(const char *name, const void *data, opt_get_cb get,
 {
 	struct cmus_opt *opt = xnew(struct cmus_opt, 1);
 	struct list_head *item;
-
-	fprintf(stderr, "adding %s\n", name);
 
 	opt->name = name;
 	opt->data = (void *)data;
@@ -1584,7 +1576,6 @@ void options_exit(void)
 
 		buf[0] = 0;
 		opt->get(opt->data, buf, OPTION_MAX_SIZE);
-		fprintf(stderr, "saving %s\n", opt->name);
 		fprintf(f, "set %s=%s\n", opt->name, buf);
 	}
 

--- a/options.c
+++ b/options.c
@@ -1475,6 +1475,8 @@ void options_add(void)
 		option_add(attr_names[i], &attrs[i], get_attr, set_attr, NULL,
 				0);
 
+	set_album_path_ignore_re(NULL, "cd[0-9]");
+
 	ip_add_options();
 	op_add_options();
 }

--- a/options.h
+++ b/options.h
@@ -21,7 +21,6 @@
 
 #include "list.h"
 
-#include <sys/types.h>
 #include <regex.h>
 
 #define OPTION_MAX_SIZE	4096

--- a/options.h
+++ b/options.h
@@ -21,6 +21,9 @@
 
 #include "list.h"
 
+#include <sys/types.h>
+#include <regex.h>
+
 #define OPTION_MAX_SIZE	4096
 
 typedef void (*opt_get_cb)(void *data, char *buf, size_t size);
@@ -141,6 +144,7 @@ extern int rewind_offset;
 extern int skip_track_info;
 extern int mouse;
 extern int mpris;
+extern regex_t album_path_ignore_re;
 
 extern const char * const aaa_mode_names[];
 extern const char * const view_names[NR_VIEWS + 1];

--- a/options.h
+++ b/options.h
@@ -144,6 +144,7 @@ extern int rewind_offset;
 extern int skip_track_info;
 extern int mouse;
 extern int mpris;
+extern int separate_albums_by_path;
 extern regex_t album_path_ignore_re;
 
 extern const char * const aaa_mode_names[];

--- a/tree.c
+++ b/tree.c
@@ -913,11 +913,11 @@ static struct album *do_find_album(const struct album *album,
 	return NULL;
 }
 
-/* album_dup_count return values:
- *   0 => there are no albums matching the filename; NULL is returned
- *  -1 => there is an album allowing the filename; it is returned
- *  >0 => there are album_dup_count duplicated albums for filename; NULL is returned
- * */
+/* Values must be negative */
+enum find_album_result {
+	FIND_ALBUM_ALLOWED_FILENAME = -1,
+};
+
 static struct album *find_album(struct album *album, char *filename, int *album_dup_count)
 {
 	struct album *a;
@@ -928,7 +928,7 @@ static struct album *find_album(struct album *album, char *filename, int *album_
 	rb_for_each_entry(a, tmp, &album->artist->album_root, tree_node) {
 		if (special_album_cmp(album, a) == 0) {
 			if (!separate_albums_by_path || !album_path_disagrees(a, filename)) {
-				*album_dup_count = -1;
+				*album_dup_count = FIND_ALBUM_ALLOWED_FILENAME;
 				return a;
 			}
 			*album_dup_count = 1 + *album_dup_count;
@@ -1069,7 +1069,7 @@ void tree_add_track(struct tree_track *track)
 		album = find_album(new_album, ti->filename, &album_dup_count);
 		new_album->dup_id = album_dup_count + 1;
 		if (album) {
-			if (album_dup_count < 0)
+			if (album_dup_count == FIND_ALBUM_ALLOWED_FILENAME)
 				album_free(new_album);
 			else
 				album = NULL;

--- a/tree.c
+++ b/tree.c
@@ -921,7 +921,7 @@ static struct album *find_album(struct album *album, char *filename, int *album_
 	/* do a linear search because we want find albums with different date */
 	rb_for_each_entry(a, tmp, &album->artist->album_root, tree_node) {
 		if (special_album_cmp(album, a) == 0) {
-			if (!album_path_disagrees(a, filename)) {
+			if (!separate_albums_by_path || !album_path_disagrees(a, filename)) {
 				*album_dup_count = -1;
 				return a;
 			}

--- a/tree.c
+++ b/tree.c
@@ -611,31 +611,31 @@ static int special_assign_album_filename(void *data, struct track_info *ti) {
 }
 
 static int album_path_disagrees(struct album *album, const char *filename) {
-	char *album_filename;
-	char *album_filename_1, *filename_1;
-	char *album_filename_2, *filename_2;
+	char *album_filepath;
+	char *albfp_eaten, *albfp_eaten_diff;
+	char *filen_eaten, *filen_eaten_diff;
 	char ca, cf;
 	char *sa, *sf;
 	int ret;
 
-	album_for_each_track(album, special_assign_album_filename, (void*) &album_filename, 0);
+	album_for_each_track(album, special_assign_album_filename, (void*) &album_filepath, 0);
 
-	album_filename_1 = xstrdup(album_filename);
-	filename_1 = xstrdup(filename);
+	albfp_eaten = xstrdup(album_filepath);
+	filen_eaten = xstrdup(filename);
 
-	eat_dirs_ignored_in_album_path(album_filename_1);
-	eat_dirs_ignored_in_album_path(filename_1);
+	eat_dirs_ignored_in_album_path(albfp_eaten);
+	eat_dirs_ignored_in_album_path(filen_eaten);
 
-	album_filename_2 = album_filename_1;
-	filename_2 = filename_1;
+	albfp_eaten_diff = albfp_eaten;
+	filen_eaten_diff = filen_eaten;
 
-	while ((ca = *album_filename_2++) && (cf = *filename_2++) && ca == cf) {}
-	sa = strchr(--album_filename_2, '/');
-	sf = strchr(--filename_2, '/');
+	while ((ca = *albfp_eaten_diff++) && (cf = *filen_eaten_diff++) && ca == cf) {}
+	sa = strchr(--albfp_eaten_diff, '/');
+	sf = strchr(--filen_eaten_diff, '/');
 	ret = sa || sf;
 
-	free(album_filename_1);
-	free(filename_1);
+	free(albfp_eaten);
+	free(filen_eaten);
 
 	return ret;
 }

--- a/tree.c
+++ b/tree.c
@@ -681,15 +681,15 @@ static inline const char *album_sort_collkey(const struct album *a)
 
 static inline int special_album_cmp_dup(const struct album *a, const struct album *b)
 {
-		int a_dup = a->dup_id;
-		int b_dup = b->dup_id;
-		if (a_dup <= 0 || b_dup <= 0)
-			return 0;
-		if (a_dup < b_dup)
-			return -1;
-		else if (a_dup > b_dup)
-			return +1;
+	int a_dup = a->dup_id;
+	int b_dup = b->dup_id;
+	if (a_dup <= 0 || b_dup <= 0)
 		return 0;
+	if (a_dup < b_dup)
+		return -1;
+	else if (a_dup > b_dup)
+		return +1;
+	return 0;
 }
 
 static int special_album_cmp(const struct album *a, const struct album *b)

--- a/tree.c
+++ b/tree.c
@@ -734,11 +734,7 @@ static inline int special_album_cmp_dup(const struct album *a, const struct albu
 	int b_dup = b->dup_id;
 	if (a_dup <= 0 || b_dup <= 0)
 		return 0;
-	if (a_dup < b_dup)
-		return -1;
-	else if (a_dup > b_dup)
-		return +1;
-	return 0;
+	return a_dup - b_dup;
 }
 
 static int special_album_cmp(const struct album *a, const struct album *b)

--- a/tree.c
+++ b/tree.c
@@ -587,13 +587,9 @@ static void eat_dirs_ignored_in_album_path(char *s) {
 			break;
 		};
 
-		char ch_before, ch_after;
-		ch_before = (m0.rm_so >= 1) ? s[m0.rm_so-1] : 0;
-		ch_after = (m0.rm_eo >= 1) ? s[m0.rm_eo] : 0;
+		char ch_after = (m0.rm_eo >= 1) ? s[m0.rm_eo] : 0;
 
-		if ((ch_before != '/' && ch_before != '\\') ||
-			(ch_after != '/' && ch_after != '\\'))
-		{
+		if (ch_after != '/' && ch_after != '\\') {
 			s += m0.rm_eo;
 		} else {
 			l_m = m0.rm_eo - m0.rm_so;

--- a/tree.c
+++ b/tree.c
@@ -897,6 +897,11 @@ static struct album *do_find_album(const struct album *album,
 	return NULL;
 }
 
+/* album_dup_count return values:
+ *   0 => there are no albums matching the filename; NULL is returned
+ *  -1 => there is an album allowing the filename; it is returned
+ *  >0 => there are album_dup_count duplicated albums for filename; NULL is returned
+ * */
 static struct album *find_album(struct album *album, char *filename, int *album_dup_count)
 {
 	struct album *a;

--- a/tree.c
+++ b/tree.c
@@ -583,11 +583,11 @@ static void print_re_error(int errcode, regex_t *re) {
 	regerror(errcode, re, buf, len+1);
 }
 
-static void eat_album_path_ignores(char *s) {
+static void eat_dirs_ignored_in_album_path(char *s) {
 	regex_t re;
 	regmatch_t m0;
 	int rc;
-	const char re_src[] = "/cd[0-9]/";
+	const char re_src[] = "cd[0-9]";
 
 	fprintf(stderr, "Compiling re '%s'\r\n", re_src);
 	rc = regcomp(&re, re_src, REG_EXTENDED);
@@ -603,14 +603,32 @@ static void eat_album_path_ignores(char *s) {
 		l = strlen(s);
 		fprintf(stderr, "Before matching: '%s'\r\n", s);
 		rc = regexec(&re, s, 1, &m0, 0);
-		if (rc == REG_NOMATCH || m0.rm_so < 0)
-			break;
 
-		l_m = m0.rm_eo - m0.rm_so;
-		l_tail = l - l_m - m0.rm_so;
-		for (i = 0; i <= l_tail; i++)
-			s[m0.rm_so + i] = s[m0.rm_eo + i];
-		fprintf(stderr, "After matching: %d '%s'\r\n", (int)m0.rm_so, s);
+		fprintf(stderr, "match code: %d %d\r\n", rc, REG_NOMATCH);
+		if (rc == REG_NOMATCH || m0.rm_so < 0) {
+			break;
+		};
+
+		char ch_before, ch_after;
+		fprintf(stderr, "here\r\n");
+		ch_before = (m0.rm_so >= 1) ? s[m0.rm_so-1] : 0;
+		fprintf(stderr, "ch_before '%c'\r\n", ch_before);
+		ch_after = (m0.rm_eo >= 1) ? s[m0.rm_eo] : 0;
+		fprintf(stderr, "ch_after '%c'\r\n", ch_after);
+
+		if ((ch_before != '/' && ch_before != '\\') ||
+			(ch_after != '/' && ch_after != '\\'))
+		{
+			fprintf(stderr, "Before advance: '%s'\r\n", s);
+			s += m0.rm_eo;
+			fprintf(stderr, "After advance: '%s'\r\n", s);
+		} else {
+			l_m = m0.rm_eo - m0.rm_so;
+			l_tail = l - l_m - m0.rm_so;
+			for (i = 0; i <= l_tail; i++)
+				s[m0.rm_so + i] = s[m0.rm_eo + i];
+			fprintf(stderr, "After matching: %d '%s'\r\n", (int)m0.rm_so, s);
+		}
 	}
 }
 
@@ -630,11 +648,11 @@ static int album_path_disagrees(struct album *album, const char *filename) {
 
 	album_for_each_track(album, special_assign_album_filename, (void*) &album_filename, 0);
 
-	album_filename_1 = strdup(album_filename);
-	filename_1 = strdup(filename);
+	album_filename_1 = xstrdup(album_filename);
+	filename_1 = xstrdup(filename);
 
-	eat_album_path_ignores(album_filename_1);
-	eat_album_path_ignores(filename_1);
+	eat_dirs_ignored_in_album_path(album_filename_1);
+	eat_dirs_ignored_in_album_path(filename_1);
 
 	album_filename_2 = album_filename_1;
 	filename_2 = filename_1;

--- a/tree.c
+++ b/tree.c
@@ -30,8 +30,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <strings.h>
-#include <sys/types.h>
-#include <regex.h>
 
 struct searchable *tree_searchable;
 struct window *lib_tree_win;
@@ -574,27 +572,12 @@ static void album_free(struct album *album)
 	free(album);
 }
 
-static void print_re_error(int errcode, regex_t *re) {
-	size_t len;
-	char *buf;
-
-	len = regerror(errcode, re, NULL, 0);
-	buf = malloc(len+1);
-	regerror(errcode, re, buf, len+1);
-}
-
 static void eat_dirs_ignored_in_album_path(char *s) {
-	regex_t re;
 	regmatch_t m0;
 	int rc;
 	const char re_src[] = "cd[0-9]";
 
 	fprintf(stderr, "Compiling re '%s'\r\n", re_src);
-	rc = regcomp(&re, re_src, REG_EXTENDED);
-	if (rc) {
-		print_re_error(rc, &re);
-		exit(1);
-	}
 
 	while (1) {
 		int l, l_m, l_tail;
@@ -602,7 +585,7 @@ static void eat_dirs_ignored_in_album_path(char *s) {
 
 		l = strlen(s);
 		fprintf(stderr, "Before matching: '%s'\r\n", s);
-		rc = regexec(&re, s, 1, &m0, 0);
+		rc = regexec(&album_path_ignore_re, s, 1, &m0, 0);
 
 		fprintf(stderr, "match code: %d %d\r\n", rc, REG_NOMATCH);
 		if (rc == REG_NOMATCH || m0.rm_so < 0) {

--- a/tree.c
+++ b/tree.c
@@ -628,15 +628,15 @@ static int album_path_disagrees(struct album *album, const char *filename) {
 
 	if (!albfp_alloc) {
 		albfp_alloc = 200;
-		albfp_eaten = malloc(albfp_alloc);
+		albfp_eaten = xmalloc(albfp_alloc);
 		filen_alloc = 200;
-		filen_eaten = malloc(filen_alloc);
+		filen_eaten = xmalloc(filen_alloc);
 	}
 	while ((albfp_len >= albfp_alloc) || (filen_len >= filen_alloc)) {
 		albfp_alloc *= 1.5;
-		albfp_eaten = realloc(albfp_eaten, albfp_alloc);
+		albfp_eaten = xrealloc(albfp_eaten, albfp_alloc);
 		filen_alloc *= 1.5;
-		filen_eaten = realloc(filen_eaten, filen_alloc);
+		filen_eaten = xrealloc(filen_eaten, filen_alloc);
 	}
 
 	strcpy(albfp_eaten, album_filepath);

--- a/tree.c
+++ b/tree.c
@@ -575,42 +575,31 @@ static void album_free(struct album *album)
 static void eat_dirs_ignored_in_album_path(char *s) {
 	regmatch_t m0;
 	int rc;
-	const char re_src[] = "cd[0-9]";
-
-	fprintf(stderr, "Compiling re '%s'\r\n", re_src);
 
 	while (1) {
 		int l, l_m, l_tail;
 		int i;
 
 		l = strlen(s);
-		fprintf(stderr, "Before matching: '%s'\r\n", s);
 		rc = regexec(&album_path_ignore_re, s, 1, &m0, 0);
 
-		fprintf(stderr, "match code: %d %d\r\n", rc, REG_NOMATCH);
 		if (rc == REG_NOMATCH || m0.rm_so < 0) {
 			break;
 		};
 
 		char ch_before, ch_after;
-		fprintf(stderr, "here\r\n");
 		ch_before = (m0.rm_so >= 1) ? s[m0.rm_so-1] : 0;
-		fprintf(stderr, "ch_before '%c'\r\n", ch_before);
 		ch_after = (m0.rm_eo >= 1) ? s[m0.rm_eo] : 0;
-		fprintf(stderr, "ch_after '%c'\r\n", ch_after);
 
 		if ((ch_before != '/' && ch_before != '\\') ||
 			(ch_after != '/' && ch_after != '\\'))
 		{
-			fprintf(stderr, "Before advance: '%s'\r\n", s);
 			s += m0.rm_eo;
-			fprintf(stderr, "After advance: '%s'\r\n", s);
 		} else {
 			l_m = m0.rm_eo - m0.rm_so;
 			l_tail = l - l_m - m0.rm_so;
 			for (i = 0; i <= l_tail; i++)
 				s[m0.rm_so + i] = s[m0.rm_eo + i];
-			fprintf(stderr, "After matching: %d '%s'\r\n", (int)m0.rm_so, s);
 		}
 	}
 }


### PR DESCRIPTION
Previously, directories 'a/c' and 'b/c'
would be considered the same 'c' album:

  c:------------
  a/c/1.wav
  b/c/1.wav
  a/c/2.wav
  b/c/2.wav
