### PR TITLE
added option to show or hide leading zero in minutes

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -1096,7 +1096,7 @@ status_display_program () [command]
 	`/usr/share/doc/cmus/examples/cmus-status-display`.
 
 time_show_leading_zero (true)
-	Pad shorter durations with a leading 0 instead of a leading space
+	Pad durations of less than 10 minutes with a leading 0
 
 wrap_search (true)
 	Controls whether the search wraps around the end.

--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -1095,6 +1095,9 @@ status_display_program () [command]
 	background or panel for example.  See
 	`/usr/share/doc/cmus/examples/cmus-status-display`.
 
+time_show_leading_zero (true)
+	Pad shorter durations with a leading 0 instead of a leading space
+
 wrap_search (true)
 	Controls whether the search wraps around the end.
 

--- a/format_print.c
+++ b/format_print.c
@@ -142,8 +142,6 @@ static void print_time(int t)
 	stack[p++] = m % 10 + '0';
 	if (m / 10 || h || time_show_leading_zero)
 		stack[p++] = m / 10 + '0';
-	else
-		stack[p++] = ' ';
 	if (h) {
 		stack[p++] = ':';
 		do {

--- a/format_print.c
+++ b/format_print.c
@@ -140,7 +140,10 @@ static void print_time(int t)
 	stack[p++] = s / 10 + '0';
 	stack[p++] = ':';
 	stack[p++] = m % 10 + '0';
-	stack[p++] = m / 10 + '0';
+	if (m / 10 || h || time_show_leading_zero)
+		stack[p++] = m / 10 + '0';
+	else
+		stack[p++] = ' ';
 	if (h) {
 		stack[p++] = ':';
 		do {

--- a/options.c
+++ b/options.c
@@ -82,6 +82,7 @@ int auto_expand_albums_selcur = 1;
 int show_all_tracks = 1;
 int mouse = 0;
 int mpris = 1;
+int time_show_leading_zero = 1;
 
 int colors[NR_COLORS] = {
 	-1,
@@ -1080,6 +1081,24 @@ static void toggle_mpris(void *data)
 	mpris ^= 1;
 }
 
+static void get_time_show_leading_zero(void *data, char *buf, size_t size)
+{
+	strscpy(buf, bool_names[time_show_leading_zero], size);
+}
+
+static void set_time_show_leading_zero(void *data, const char *buf)
+{
+	if (!parse_bool(buf, &time_show_leading_zero))
+		return;
+	update_statusline();
+}
+
+static void toggle_time_show_leading_zero(void *data)
+{
+	time_show_leading_zero ^= 1;
+	update_statusline();
+}
+
 static void get_lib_add_filter(void *data, char *buf, size_t size)
 {
 	strscpy(buf, lib_add_filter ? lib_add_filter : "", size);
@@ -1322,6 +1341,7 @@ static const struct {
 	DT(skip_track_info)
 	DT(mouse)
 	DT(mpris)
+	DT(time_show_leading_zero)
 	DN(lib_add_filter)
 	{ NULL, NULL, NULL, NULL, 0 }
 };

--- a/options.h
+++ b/options.h
@@ -141,6 +141,7 @@ extern int rewind_offset;
 extern int skip_track_info;
 extern int mouse;
 extern int mpris;
+extern int time_show_leading_zero;
 
 extern const char * const aaa_mode_names[];
 extern const char * const view_names[NR_VIEWS + 1];


### PR DESCRIPTION
# 553

With this change users can now use the option `time_show_leading_zero=true` to always show two digits for the minutes (this is the default):
![leading_zero](https://cloud.githubusercontent.com/assets/22779760/19463421/dfa87352-94c1-11e6-83f0-bf18c17e9192.png)
And `time_show_leading_zero=false` to only show 2 digits padded with a space if the duration is more than 10 minutes:
![no_leading_zero](https://cloud.githubusercontent.com/assets/22779760/19463441/16ab002c-94c2-11e6-9240-9abdb6a325f8.png)
