### PR TITLE
fix a crash where buf is freed but never alloced

### DIFF
--- a/cue.c
+++ b/cue.c
@@ -480,7 +480,6 @@ struct cue_sheet *cue_from_file(const char *file)
 		return NULL;
 	struct cue_sheet *rv = cue_parse(buf, size);
 	munmap(buf, size);
-	free(buf);
 	return rv;
 }
 


### PR DESCRIPTION
buf is created by mmap and destroyed by munmap. there's no need to free it.

see https://github.com/cmus/cmus/issues/559