### PR TITLE
Fix flac plugin for small files

### DIFF
--- a/ip/flac.c
+++ b/ip/flac.c
@@ -357,11 +357,9 @@ static int flac_open(struct input_plugin_data *ip_data)
 	}
 
 	ip_data->sf = 0;
-	while (priv->buf_wpos == 0 && priv->pos < priv->len) {
-		if (!F(process_single)(priv->dec)) {
-			free_priv(ip_data);
-			return -IP_ERROR_ERRNO;
-		}
+	if (!F(process_until_end_of_metadata)(priv->dec)) {
+		free_priv(ip_data);
+		return -IP_ERROR_ERRNO;
 	}
 
 	if (!ip_data->sf) {

--- a/ip/flac.c
+++ b/ip/flac.c
@@ -397,9 +397,11 @@ static int flac_read(struct input_plugin_data *ip_data, char *buffer, int count)
 		BUG_ON(avail < 0);
 		if (avail > 0)
 			break;
-		if (priv->pos == priv->len)
+		FLAC__bool internal_error = !F(process_single)(priv->dec);
+		FLAC__StreamDecoderState state = F(get_state)(priv->dec);
+		if (state == E(END_OF_STREAM))
 			return 0;
-		if (!F(process_single)(priv->dec)) {
+		if (state == E(ABORTED) || state == E(OGG_ERROR) || internal_error) {
 			d_print("process_single failed\n");
 			return -1;
 		}


### PR DESCRIPTION
The flac library does not output decoded data until it has processed a
certain amount of input data or until the end of the stream is reached.
The old version of the code did not take this into account. In
particular, us having inputted all of our data into the flac plugin does
not mean that the flac plugin has outputted all of its data yet.

Hence we remove the `priv->pos == priv-len` check and instead ask the
flac library directly if it's done.
---

Fixes #440.
