### PR TITLE
Reduce pulse plugin priority

### DIFF
--- a/op/pulse.c
+++ b/op/pulse.c
@@ -270,7 +270,7 @@ static int _pa_create_context(void)
 
 	pa_context_set_state_callback(pa_ctx, _pa_context_running_cb, NULL);
 
-	rc = pa_context_connect(pa_ctx, NULL, PA_CONTEXT_NOFAIL, NULL);
+	rc = pa_context_connect(pa_ctx, NULL, PA_CONTEXT_NOFLAGS, NULL);
 	if (rc)
 		goto out_fail;
 


### PR DESCRIPTION
The pulse plugin might be much better than the alsa plugin but it doesn't matter if it simply gives the user a blank screen. With this change the alsa plugin is the new default on an alsa/pulse machine.
