### PR TITLE
Small OpenBSD/sndio fixes

### DIFF
--- a/configure
+++ b/configure
@@ -21,12 +21,8 @@ check_cflags()
 
 check_sndio()
 {
-	case `uname -s` in
-	OpenBSD|FreeBSD)
-		check_library SNDIO "" "-lsndio"
-		return $?
-	esac
-	return 1
+	check_library SNDIO "" "-lsndio"
+	return $?
 }
 
 check_coreaudio()

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -639,12 +639,6 @@ check_x11()
 # adds PTHREAD_CFLAGS and PTHREAD_LIBS to config.mk
 check_pthread()
 {
-	case `uname -s` in
-	OpenBSD)
-		PTHREAD_LIBS="$PTHREAD_LIBS -pthread"
-		;;
-	esac
-
 	for __libs in "$PTHREAD_LIBS" -lpthread -lc_r -lkse
 	do
 		test -z "$__libs" && continue


### PR DESCRIPTION
Hi,

Here are two small OpenBSD patches for cmus (I maintain the official OpenBSD port, and I wrote the sndio output plugin a few years ago).

The first patch removes the -pthread special case for OpenBSD. No supported OpenBSD release requires this anymore.

The second one checks for sndio everywhere, since it's no longer BSD-only (and the current code omits Bitrig, an OpenBSD fork):
http://www.sndio.org/

I think these 2 patches + 84f33584be9150d9783751dc3ccbd726e33072c7 ("Support 32-bit/24-bit encoding in sndio output plugin") could be backported to 2.7.2, FWIW.