### PR TITLE
Implement BASS input plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ flac-objs		:= ip/flac.lo
 mad-objs		:= ip/mad.lo ip/nomad.lo
 mikmod-objs		:= ip/mikmod.lo
 modplug-objs		:= ip/modplug.lo
+bass-objs		:= ip/bass.lo
 mpc-objs		:= ip/mpc.lo
 vorbis-objs		:= ip/vorbis.lo
 opus-objs		:= ip/opus.lo
@@ -90,6 +91,7 @@ ip-$(CONFIG_FLAC)	+= ip/flac.so
 ip-$(CONFIG_MAD)	+= ip/mad.so
 ip-$(CONFIG_MIKMOD)	+= ip/mikmod.so
 ip-$(CONFIG_MODPLUG)	+= ip/modplug.so
+ip-$(CONFIG_BASS)	+= ip/bass.so
 ip-$(CONFIG_MPC)	+= ip/mpc.so
 ip-$(CONFIG_VORBIS)	+= ip/vorbis.so
 ip-$(CONFIG_OPUS)	+= ip/opus.so
@@ -106,6 +108,7 @@ $(flac-objs):		CFLAGS += $(FLAC_CFLAGS)
 $(mad-objs):		CFLAGS += $(MAD_CFLAGS)
 $(mikmod-objs):		CFLAGS += $(MIKMOD_CFLAGS)
 $(modplug-objs):	CFLAGS += $(MODPLUG_CFLAGS)
+$(bass-objs):		CFLAGS += $(BASS_CFLAGS)
 $(mpc-objs):		CFLAGS += $(MPC_CFLAGS)
 $(vorbis-objs):		CFLAGS += $(VORBIS_CFLAGS)
 $(opus-objs):		CFLAGS += $(OPUS_CFLAGS)
@@ -129,6 +132,9 @@ ip/mikmod.so: $(mikmod-objs) $(libcmus-y)
 
 ip/modplug.so: $(modplug-objs) $(libcmus-y)
 	$(call cmd,ld_dl,$(MODPLUG_LIBS))
+
+ip/bass.so: $(bass-objs) $(libcmus-y)
+	$(call cmd,ld_dl,$(BASS_LIBS))
 
 ip/mpc.so: $(mpc-objs) $(libcmus-y)
 	$(call cmd,ld_dl,$(MPC_LIBS))

--- a/configure
+++ b/configure
@@ -223,6 +223,13 @@ check_modplug()
 	return 0
 }
 
+check_bass()
+{
+    check_header bass.h &&
+    check_library BASS "" "-lbass"
+    return $?
+}
+
 check_vtx()
 {
 	check_header ayemu.h &&
@@ -436,6 +443,7 @@ DEBUG=1
 HAVE_CDDB=n
 CONFIG_TREMOR=n
 CONFIG_MIKMOD=n
+CONFIG_BASS=n
 USE_FALLBACK_IP=n
 HAVE_BYTESWAP_H=n
 HAVE_STRDUP=n
@@ -468,6 +476,7 @@ Optional Features: y/n
   CONFIG_JACK           JACK                                            [auto]
   CONFIG_MAD            MPEG Audio Decoder (.mp3, .mp2, streams)        [auto]
   CONFIG_MIKMOD         libmikmod (.mod, .x3m, ...)                     [n]
+  CONFIG_BASS           libbass (.mod, .x3m, ...)                       [n]
   CONFIG_MODPLUG        libmodplug (.mod, .x3m, ...)                    [auto]
   CONFIG_MP4            MPEG-4 AAC (.mp4, .m4a, .m4b)                   [auto]
   CONFIG_MPC            libmpcdec (Musepack .mpc, .mpp, .mp+)           [auto]
@@ -529,6 +538,7 @@ check check_flac       CONFIG_FLAC
 check check_mad        CONFIG_MAD
 check check_mikmod     CONFIG_MIKMOD
 check check_modplug    CONFIG_MODPLUG
+check check_bass       CONFIG_BASS
 check check_mpc        CONFIG_MPC
 check check_vorbis     CONFIG_VORBIS
 check check_opus       CONFIG_OPUS
@@ -594,6 +604,6 @@ makefile_vars \
 	CONFIG_MAD CONFIG_MIKMOD CONFIG_MODPLUG CONFIG_MP4 CONFIG_MPC \
 	CONFIG_MPRIS CONFIG_OPUS CONFIG_OSS CONFIG_PULSE CONFIG_ROAR \
 	CONFIG_SAMPLERATE CONFIG_SNDIO CONFIG_SUN CONFIG_VORBIS CONFIG_VTX \
-	CONFIG_WAV CONFIG_WAVEOUT CONFIG_WAVPACK
+	CONFIG_WAV CONFIG_WAVEOUT CONFIG_WAVPACK CONFIG_BASS
 
 generate_config_mk

--- a/ip/bass.c
+++ b/ip/bass.c
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2008-2013 Various Authors
+ * Copyright 2016 Nic Soudée
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ip.h"
+#include "xmalloc.h"
+#include "comment.h"
+#include "bass.h"
+
+#define BITS (16)
+#define FREQ (44100)
+#define CHANS (2)
+
+struct bass_private {
+	DWORD chan;
+};
+
+static int bass_init(void)
+{
+	static int inited = 0;
+
+	if (inited)
+		return 1;
+
+	if (!BASS_Init(0, FREQ, 0, 0, NULL))
+		return 0;
+
+	inited = 1;
+	return 1;
+}
+
+static int bass_open(struct input_plugin_data *ip_data)
+{
+	struct bass_private *priv;
+	DWORD chan;
+	DWORD flags;
+
+	if (!bass_init())
+		return -IP_ERROR_INTERNAL;
+
+	flags = BASS_MUSIC_DECODE | BASS_MUSIC_RAMP | BASS_MUSIC_PRESCAN;
+	chan = BASS_MusicLoad(FALSE, ip_data->filename, 0, 0, flags, 0);
+
+	if (!chan) {
+		return -IP_ERROR_ERRNO;
+	}
+
+	priv = xnew(struct bass_private, 1);
+	priv->chan = chan;
+	ip_data->private = priv;
+	ip_data->sf = sf_bits(BITS) | sf_rate(FREQ) | sf_channels(CHANS) | sf_signed(1);
+	ip_data->sf |= sf_host_endian();
+	channel_map_init_stereo(ip_data->channel_map);
+	return 0;
+}
+
+static int bass_close(struct input_plugin_data *ip_data)
+{
+	struct bass_private *priv = ip_data->private;
+
+	BASS_MusicFree(priv->chan);
+	free(priv);
+	ip_data->private = NULL;
+	return 0;
+}
+
+static int bass_read(struct input_plugin_data *ip_data, char *buffer, int count)
+{
+	int length;
+	struct bass_private *priv = ip_data->private;
+	length = BASS_ChannelGetData(priv->chan, buffer, count);
+	if (length < 0) {
+		return 0;
+	}
+	return length;
+}
+
+static int bass_seek(struct input_plugin_data *ip_data, double offset)
+{
+	struct bass_private *priv = ip_data->private;
+	QWORD pos = (QWORD)(offset * (FREQ * CHANS * (BITS / 8)) + 0.5);
+	QWORD flags = BASS_POS_BYTE | BASS_POS_DECODE;
+
+	if (!BASS_ChannelSetPosition(priv->chan, pos, flags)) {
+		return -IP_ERROR_INTERNAL;
+	}
+	return 0;
+}
+
+static int bass_read_comments(struct input_plugin_data *ip_data,
+				struct keyval **comments)
+{
+	struct bass_private *priv = ip_data->private;
+	GROWING_KEYVALS(c);
+	const char *val;
+
+	val = BASS_ChannelGetTags(priv->chan, BASS_TAG_MUSIC_NAME);
+	if (val && val[0])
+		comments_add_const(&c, "title", val);
+	keyvals_terminate(&c);
+	*comments = c.keyvals;
+	return 0;
+}
+
+static int bass_duration(struct input_plugin_data *ip_data)
+{
+	static float length = 0;
+	int pos;
+	struct bass_private *priv = ip_data->private;
+
+	pos = BASS_ChannelGetLength(priv->chan, BASS_POS_BYTE);
+	if (pos && pos != -1) {
+		length = BASS_ChannelBytes2Seconds(priv->chan, pos);
+	}
+	else {
+		length = -IP_ERROR_FUNCTION_NOT_SUPPORTED;
+	}
+	return length;
+}
+
+static long bass_bitrate(struct input_plugin_data *ip_data)
+{
+	return -IP_ERROR_FUNCTION_NOT_SUPPORTED;
+}
+
+static const char *bass_type_to_string(int type)
+{
+	/* from <bass.h> */
+	switch (type) {
+		case 0x20000: return "mod";
+		case 0x20001: return "mtm";
+		case 0x20002: return "s3m";
+		case 0x20003: return "xm";
+		case 0x20004: return "it";
+	}
+	return NULL;
+}
+
+static char *bass_codec(struct input_plugin_data *ip_data)
+{
+	const char *codec;
+	int type;
+	BASS_CHANNELINFO info;
+	struct bass_private *priv = ip_data->private;
+
+	if (!(BASS_ChannelGetInfo(priv->chan, &info))) {
+		return NULL;
+	}
+	type = info.ctype;
+	codec = bass_type_to_string(type);
+	return codec ? xstrdup(codec) : NULL;
+}
+
+static char *bass_codec_profile(struct input_plugin_data *ip_data)
+{
+	return NULL;
+}
+
+const struct input_plugin_ops ip_ops = {
+	.open = bass_open,
+	.close = bass_close,
+	.read = bass_read,
+	.seek = bass_seek,
+	.read_comments = bass_read_comments,
+	.duration = bass_duration,
+	.bitrate = bass_bitrate,
+	.bitrate_current = bass_bitrate,
+	.codec = bass_codec,
+	.codec_profile = bass_codec_profile
+};
+
+const int ip_priority = 60;
+const char * const ip_extensions[] = {
+	"xm", "it", "s3m", "mod", "mtm", "umx", NULL
+};
+
+const char * const ip_mime_types[] = { NULL };
+const struct input_plugin_opt ip_options[] = { { NULL } };
+const unsigned ip_abi_version = IP_ABI_VERSION;
+


### PR DESCRIPTION
BASS is a library which provides highly accurate reproduction
of MOD, S3M, MTM, XM, IT, UMX playback. It plays more modules
correctly than both modplug and mikmod (subtle nuances in
effects, etc). This library is capable of more, but my main
goal was to get modules playing.

The library can be found here: http://www.un4seen.com