### PR TITLE
Maint 2.6 win set sel

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -246,6 +246,7 @@ tab            win-next
 ^Y             win-scroll-up
 D, delete      win-remove
 i              win-sel-cur
+\@              win-set-sel
 space          win-toggle
 g, home        win-top
 k, up          win-up
@@ -708,6 +709,12 @@ win-scroll-up (*^Y*)
 win-sel-cur (*i*)
 	Select the current track (position in library or playlist, not
 	necessarily same as the currently playing track).  Works only in views
+	1-3, does nothing in other views.
+
+win-set-sel (*\@*)
+	Set the current track (position in library or playlist, not
+	necessarily same as the currently playing track) to the current
+	selection; this is the inverse of win-sel-cur.  Works only in views
 	1-3, does nothing in other views.
 
 win-toggle (*space*)

--- a/command_mode.c
+++ b/command_mode.c
@@ -1610,6 +1610,31 @@ static void cmd_win_sel_cur(char *arg)
 	editable_unlock();
 }
 
+static void cmd_win_set_sel(char *arg)
+{
+editable_lock();
+switch (cur_view) {
+case TREE_VIEW:
+tree_activate_selected();
+break;
+case SORTED_VIEW:
+sorted_activate_selected();
+break;
+case PLAYLIST_VIEW:
+pl_activate_selected();
+break;
+case QUEUE_VIEW:
+break;
+case BROWSER_VIEW:
+break;
+case FILTERS_VIEW:
+break;
+case HELP_VIEW:
+break;
+}
+editable_unlock();
+}
+
 static void cmd_win_toggle(char *arg)
 {
 	switch (cur_view) {
@@ -2582,6 +2607,7 @@ struct command commands[] = {
 	{ "win-scroll-down",	cmd_win_scroll_down,0, 0, NULL,		  0, 0 },
 	{ "win-scroll-up",	cmd_win_scroll_up,0, 0, NULL,		  0, 0 },
 	{ "win-sel-cur",	cmd_win_sel_cur,0, 0, NULL,		  0, 0 },
+	{ "win-set-sel",	cmd_win_set_sel,0, 0, NULL,               0, 0 },
 	{ "win-toggle",		cmd_win_toggle,	0, 0, NULL,		  0, 0 },
 	{ "win-top",		cmd_win_top,	0, 0, NULL,		  0, 0 },
 	{ "win-up",		cmd_win_up,	0, 0, NULL,		  0, 0 },

--- a/data/rc
+++ b/data/rc
@@ -47,6 +47,7 @@ bind common g win-top
 bind common h seek -5
 bind common home win-top
 bind common i win-sel-cur
+bind common @ win-set-sel
 bind common j win-down
 bind common k win-up
 bind common l seek +5


### PR DESCRIPTION
Add a win-set-sel command to set the active track to the selected one, plus documentation and a keybinding.  This is useful for flow between library/playlist/queue: i.e., queue several tracks, then use win-set-sel to pick the point in the library to resume (and continue playing in order) from after the queue is exhausted.