### PR TITLE
made (backward) search a bindable command

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -200,6 +200,8 @@ x                           player-play
 z                           player-prev
 v                           player-stop
 ^L                          refresh
+/                           search-start
+?                           search-b-start
 n                           search-next
 N                           search-prev
 .                           seek +1m

--- a/command_mode.c
+++ b/command_mode.c
@@ -1400,6 +1400,16 @@ static void cmd_search_prev(char *arg)
 	}
 }
 
+static void cmd_search_start(char *arg)
+{
+	enter_search_mode();
+}
+
+static void cmd_search_b_start(char *arg)
+{
+	enter_search_backward_mode();
+}
+
 static int sorted_for_each_sel(track_info_cb cb, void *data, int reverse)
 {
 	return editable_for_each_sel(&lib_editable, cb, data, reverse);
@@ -2539,8 +2549,10 @@ struct command commands[] = {
 	{ "refresh",               cmd_refresh,          0, 0,  NULL,                 0, 0          },
 	{ "run",                   cmd_run,              1, -1, expand_program_paths, 0, CMD_UNSAFE },
 	{ "save",                  cmd_save,             0, 1,  expand_load_save,     0, CMD_UNSAFE },
+	{ "search-b-start",        cmd_search_b_start,   0, 0,  NULL,                 0, 0          },
 	{ "search-next",           cmd_search_next,      0, 0,  NULL,                 0, 0          },
 	{ "search-prev",           cmd_search_prev,      0, 0,  NULL,                 0, 0          },
+	{ "search-start",          cmd_search_start,     0, 0,  NULL,                 0, 0          },
 	{ "seek",                  cmd_seek,             1, 1,  NULL,                 0, 0          },
 	{ "set",                   cmd_set,              1, 1,  expand_options,       0, 0          },
 	{ "shell",                 cmd_shell,            1, -1, expand_program_paths, 0, CMD_UNSAFE },

--- a/data/rc
+++ b/data/rc
@@ -10,6 +10,7 @@ bind common + vol +10%
 bind common , seek -1m
 bind common - vol -10%
 bind common . seek +1m
+bind common / search-start
 bind common 1 view tree
 bind common 2 view sorted
 bind common 3 view playlist
@@ -18,6 +19,7 @@ bind common 5 view browser
 bind common 6 view filters
 bind common 7 view settings
 bind common = vol +10%
+bind common ? search-b-start
 bind common C toggle continue
 bind common D win-remove
 bind common E win-add-Q

--- a/keys.c
+++ b/keys.c
@@ -667,17 +667,9 @@ void normal_mode_ch(uchar ch)
 	if (handle_key(key_bindings[CTX_COMMON], k))
 		return;
 
-	/* these can be overridden but have default magic */
-	switch (ch) {
-	case ':':
+	/* binding can be overridden but has default magic */
+	if (ch == ':') {
 		enter_command_mode();
-		return;
-	case '/':
-		enter_search_mode();
-		return;
-	case '?':
-		enter_search_backward_mode();
-		return;
 	}
 }
 

--- a/keys.c
+++ b/keys.c
@@ -667,9 +667,17 @@ void normal_mode_ch(uchar ch)
 	if (handle_key(key_bindings[CTX_COMMON], k))
 		return;
 
-	/* binding can be overridden but has default magic */
-	if (ch == ':') {
+	/* these can be overridden but have default magic */
+	switch (ch) {
+	case ':':
 		enter_command_mode();
+		return;
+	case '/':
+		enter_search_mode();
+		return;
+	case '?':
+		enter_search_backward_mode();
+		return;
 	}
 }
 


### PR DESCRIPTION
Implements #515.

Lets you bind the search commands, which are hard coded to `/` and `?` up to now.

The search mode in the command line is still indicated by `/`/`?`. This could be changed to e.g. `search: `/`backward search: `. Thoughts?