### PR TITLE
remove trailing spaces from key in cmd_unbind() and cmd_showbind()

### DIFF
--- a/command_mode.c
+++ b/command_mode.c
@@ -706,7 +706,12 @@ static void cmd_unbind(char *arg)
 	if (*key == 0)
 		goto err;
 
-	/* FIXME: remove spaces at end */
+	/* remove trailing spaces from key */
+	char *key_end = key + strlen(key);
+	while (isspace(*(key_end-1))) {
+		key_end--;
+	}
+	*key_end = 0;
 
 	key_unbind(arg, key, flag == 'f');
 	return;
@@ -727,7 +732,12 @@ static void cmd_showbind(char *arg)
 	if (*key == 0)
 		goto err;
 
-	/* FIXME: remove spaces at end */
+	/* remove trailing spaces from key */
+	char *key_end = key + strlen(key);
+	while (isspace(*(key_end-1))) {
+		key_end--;
+	}
+	*key_end = 0;
 
 	show_binding(arg, key);
 	return;

--- a/command_mode.c
+++ b/command_mode.c
@@ -706,12 +706,7 @@ static void cmd_unbind(char *arg)
 	if (*key == 0)
 		goto err;
 
-	/* remove trailing spaces from key */
-	char *key_end = key + strlen(key);
-	while (isspace(*(key_end-1))) {
-		key_end--;
-	}
-	*key_end = 0;
+	strip_trailing_spaces(key);
 
 	key_unbind(arg, key, flag == 'f');
 	return;
@@ -732,12 +727,7 @@ static void cmd_showbind(char *arg)
 	if (*key == 0)
 		goto err;
 
-	/* remove trailing spaces from key */
-	char *key_end = key + strlen(key);
-	while (isspace(*(key_end-1))) {
-		key_end--;
-	}
-	*key_end = 0;
+	strip_trailing_spaces(key);
 
 	show_binding(arg, key);
 	return;

--- a/utils.h
+++ b/utils.h
@@ -127,6 +127,11 @@ static inline int strcmp0(const char *str1, const char *str2)
 	return strcmp(str1, str2);
 }
 
+static inline int is_space(const char ch)
+{
+	return (ch == ' ' || ch == '\t');
+}
+
 static inline int ends_with(const char *str, const char *suffix)
 {
 	return strstr(str, suffix) + strlen(suffix) == str + strlen(str);

--- a/utils.h
+++ b/utils.h
@@ -137,6 +137,15 @@ static inline int ends_with(const char *str, const char *suffix)
 	return strstr(str, suffix) + strlen(suffix) == str + strlen(str);
 }
 
+static inline void strip_trailing_spaces(char *str)
+{
+	char *end = str + strlen(str);
+	while (end > str && is_space(*(end-1))) {
+		end--;
+	}
+	*end = 0;
+}
+
 static inline uint32_t hash_str(const char *s)
 {
 	const unsigned char *p = (const unsigned char *)s;


### PR DESCRIPTION
Resolving minor FIXMEs.