### PR TITLE
MPRIS cover art display

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -817,8 +817,8 @@ altformat_trackwin [`Format String`]
 
 artfile_name (cover.jpg)
 	Cover art file name for the MPRIS interface. Can also display files up or down
-	the directory tree (e.g. *album-art/front-cover.jpg* or *../artist.jpg*).
-	Currently does not support file names with whitespace.
+	the directory tree (e.g. *album-art/front cover.jpg* or *../artist.jpg*). Use
+	whitespaces without backslashes and quotation marks (e.g. *name of album.jpg*).
 
 buffer_seconds (10) [1-300]
 	Size of player buffer in seconds.

--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -815,6 +815,11 @@ altformat_trackwin [`Format String`]
 
 	NOTE: if empty, *format_trackwin* is used instead.
 
+artfile_name (cover.jpg)
+	Cover art file name for the MPRIS interface. Can also display files up or down
+	the directory tree (e.g. *album-art/front-cover.jpg* or *../artist.jpg*).
+	Currently does not support file names with whitespace.
+
 buffer_seconds (10) [1-300]
 	Size of player buffer in seconds.
 

--- a/mpris.c
+++ b/mpris.c
@@ -385,6 +385,30 @@ static int mpris_metadata(sd_bus *_bus, const char *_path,
 		if (ti->discnumber != -1)
 			CK(mpris_msg_append_si_dict(reply, "xesam:discNumber",
 						ti->discnumber));
+		if (ti->filename && artfile_name) {
+			char filename[512];
+			char art_path[512] = "file://";
+			int num_tokens = 1;
+
+			strcpy(filename, ti->filename);
+			for (int i = 1; i < strlen(filename); i++) 
+				if (filename[i] == '/') num_tokens++;
+
+			char* tokens[num_tokens];
+			tokens[0] = strtok(filename, "/");
+
+			for (int i = 1; i < num_tokens; i++)
+				tokens[i] = strtok(NULL, "/");
+
+			for (int i = 0; i < num_tokens-1; i++) {
+				strcat(art_path, "/");
+				strcat(art_path, tokens[i]);
+			}
+			strcat(art_path, "/");
+			strcat(art_path, artfile_name);
+			CK(mpris_msg_append_ss_dict(reply, "mpris:artUrl",
+						art_path));
+		}
 	}
 
 	CK(sd_bus_message_close_container(reply));

--- a/mpris.c
+++ b/mpris.c
@@ -345,15 +345,15 @@ static int mpris_msg_append_sas_dict(sd_bus_message *m, const char *a,
 
 static char* mpris_build_artfile_path(struct track_info *ti) {
 	const char art_schema[] = "file://";
-	int len_art_schema = strlen(art_schema);
+	size_t len_art_schema = strlen(art_schema);
 
 	char *filepath = NULL;
 	filepath = xstrdup(ti->filename);
 	const char *filename = get_filename(filepath);
-	int len_filedir = strlen(filepath) - strlen(filename);
+	size_t len_filedir = strlen(filepath) - strlen(filename);
 
 	/* global variable artfile_name defined in options */
-	int len_artpath = len_filedir;
+	size_t len_artpath = len_filedir;
 	len_artpath += strlen(artfile_name);
 
 	char *art_path = xmalloc(len_art_schema + len_artpath + 1);

--- a/options.c
+++ b/options.c
@@ -57,6 +57,7 @@
 char *cdda_device = NULL;
 char *output_plugin = NULL;
 char *status_display_program = NULL;
+char *artfile_name = NULL;
 char *server_password;
 int auto_reshuffle = 1;
 int confirm_run = 1;
@@ -460,6 +461,20 @@ static void set_status_display_program(void *data, const char *buf)
 	status_display_program = NULL;
 	if (buf[0])
 		status_display_program = expand_filename(buf);
+}
+
+static void get_artfile_name(void *data, char *buf, size_t size)
+{
+	if (artfile_name)
+		strscpy(buf, artfile_name, size);
+}
+
+static void set_artfile_name(void *data, const char *buf)
+{
+	free(artfile_name);
+	artfile_name = NULL;
+	if (buf[0])
+		artfile_name = xstrdup(buf);
 }
 
 /* }}} */
@@ -1337,6 +1352,7 @@ static const struct {
 	DT(softvol)
 	DN(softvol_state)
 	DN_FLAGS(status_display_program, OPT_PROGRAM_PATH)
+	DN(artfile_name)
 	DT(wrap_search)
 	DT(skip_track_info)
 	DT(mouse)
@@ -1483,6 +1499,7 @@ void options_load(void)
 	int i;
 
 	/* initialize those that can't be statically initialized */
+	artfile_name = xstrdup("cover.jpg");
 	cdda_device = get_default_cdda_device();
 	for (i = 0; str_defaults[i].name; i++)
 		option_set(str_defaults[i].name, str_defaults[i].value);

--- a/options.h
+++ b/options.h
@@ -116,6 +116,7 @@ enum {
 extern char *cdda_device;
 extern char *output_plugin;
 extern char *status_display_program;
+extern char *artfile_name;
 extern char *server_password;
 extern int auto_expand_albums_follow;
 extern int auto_expand_albums_search;


### PR DESCRIPTION
Displays the cover art on the MPRIS interface, named by the newly added **artfile_name** option. Default value displays **cover.jpg** file in the song's folder. It can also display files up or down in directory tree (e.g. *album-art/front cover.jpg* or *../artist.jpg*). Use whitespaces without backslashes or quotation marks (e.g. **name of album.jpg**).
TODO: Support for internal variables like %a,  %l.