### PR TITLE
Use 3 bytes per sample when playing 24-bit files in op/sndio

### DIFF
--- a/op/sndio.c
+++ b/op/sndio.c
@@ -86,6 +86,7 @@ static int sndio_set_sf(sample_format_t sf)
 		break;
 	case 24:
 		par.bits = 24;
+		par.bps = 3;
 		break;
 	case 16:
 		par.bits = 16;


### PR DESCRIPTION
When par.bps is unset sndio will default to SIO_BPS(bits) ("the
smallest value for bps that is a power of two and that is large enough
to hold bits" sio_open(3)).  4 bps in the case of 24 bits which leads
to a horrible whitenoise screeching sound.

I'm unsure why it worked in cmus 2.7.1 without this change.