### PR TITLE
Canonicalize path when adding files to collection

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -1040,6 +1040,11 @@ replaygain_limit (true)
 replaygain_preamp (0.0)
 	Replay gain preamplification in decibels.
 
+resolve_symlinks (true)
+	Resolve any symlinks filenames before adding them to the library. This
+	prevents duplicates resulting from files reachable by multiple paths.
+	The path displayed by %f format is the real path of the added file.
+
 resume (false)
 	Resume playback on startup.
 

--- a/job.c
+++ b/job.c
@@ -42,6 +42,8 @@
 #include <errno.h>
 #include <sys/mman.h>
 
+extern int resolve_symlinks;
+
 enum job_result_var {
 	JOB_RES_ADD,
 	JOB_RES_UPDATE,
@@ -166,6 +168,11 @@ static int add_file_cue(const char *filename);
 static void add_file(const char *filename, int force)
 {
 	struct track_info *ti;
+	char buf[PATH_MAX];
+
+	if (resolve_symlinks) {
+		filename = realpath(filename, buf);
+	}
 
 	if (!is_cue_url(filename)) {
 		if (force || lookup_cache_entry(filename, hash_str(filename)) == NULL) {

--- a/options.c
+++ b/options.c
@@ -83,6 +83,7 @@ int show_all_tracks = 1;
 int mouse = 0;
 int mpris = 1;
 int time_show_leading_zero = 1;
+int resolve_symlinks = 1;
 
 int colors[NR_COLORS] = {
 	-1,
@@ -1122,6 +1123,21 @@ static void set_lib_add_filter(void *data, const char *buf)
 	lib_set_add_filter(expr);
 }
 
+static void get_resolve_symlinks(void *data, char *buf, size_t size)
+{
+	strscpy(buf, bool_names[resolve_symlinks], size);
+}
+
+static void set_resolve_symlinks(void *data, const char *buf)
+{
+	parse_bool(buf, &resolve_symlinks);
+}
+
+static void toggle_resolve_symlinks(void *data)
+{
+	resolve_symlinks ^= 1;
+}
+
 /* }}} */
 
 /* special callbacks (id set) {{{ */
@@ -1343,6 +1359,7 @@ static const struct {
 	DT(mpris)
 	DT(time_show_leading_zero)
 	DN(lib_add_filter)
+	DT(resolve_symlinks)
 	{ NULL, NULL, NULL, NULL, 0 }
 };
 

--- a/options.h
+++ b/options.h
@@ -142,6 +142,7 @@ extern int skip_track_info;
 extern int mouse;
 extern int mpris;
 extern int time_show_leading_zero;
+extern int resolve_symlinks;
 
 extern const char * const aaa_mode_names[];
 extern const char * const view_names[NR_VIEWS + 1];


### PR DESCRIPTION
When there are symlinks involved, a file can be rechable via multiple filenames. In that case a file can be added multiple times to the library.

This PR uses realpath to resolve symlinks before adding files to the collection, mitigating this issue.

fixes #423 