### PR TITLE
Fix initialization of union

### DIFF
--- a/expr.c
+++ b/expr.c
@@ -229,10 +229,6 @@ static struct expr *expr_new(int type)
 	struct expr *new = xnew0(struct expr, 1);
 
 	new->type = type;
-	new->key = NULL;
-	new->parent = NULL;
-	new->left = NULL;
-	new->right = NULL;
 
 	return new;
 }

--- a/expr.c
+++ b/expr.c
@@ -233,6 +233,10 @@ static struct expr *expr_new(int type)
 	new->parent = NULL;
 	new->left = NULL;
 	new->right = NULL;
+	new->estr.glob_head.next = NULL;
+	new->estr.glob_head.prev = NULL;
+	new->estr.op = SOP_EQ;
+
 	return new;
 }
 

--- a/expr.c
+++ b/expr.c
@@ -226,16 +226,13 @@ static int tokenize(struct list_head *head, const char *str)
 
 static struct expr *expr_new(int type)
 {
-	struct expr *new = xnew(struct expr, 1);
+	struct expr *new = xnew0(struct expr, 1);
 
 	new->type = type;
 	new->key = NULL;
 	new->parent = NULL;
 	new->left = NULL;
 	new->right = NULL;
-	new->estr.glob_head.next = NULL;
-	new->estr.glob_head.prev = NULL;
-	new->estr.op = SOP_EQ;
 
 	return new;
 }


### PR DESCRIPTION
I just discovered the `expr` struct isn't being fully initialized.