### PR TITLE
adding composer_as_artist setting

### DIFF
--- a/options.c
+++ b/options.c
@@ -83,6 +83,7 @@ int show_all_tracks = 1;
 int mouse = 0;
 int mpris = 1;
 int time_show_leading_zero = 1;
+int composer_as_artist = 0;
 int start_view = TREE_VIEW;
 
 int colors[NR_COLORS] = {
@@ -1100,6 +1101,69 @@ static void toggle_time_show_leading_zero(void *data)
 	update_statusline();
 }
 
+static void get_composer_as_artist(void *data, char *buf, size_t size)
+{
+	strscpy(buf, bool_names[composer_as_artist], size);
+}
+
+struct tree_track_list {
+    struct tree_track_list *next;
+    struct tree_track *track;
+};
+
+static void rebuild_tree(void) {
+	/* going to pull all the tracks out of the tree and then add them back in */
+	struct tree_track_list *tree_track_list = NULL;
+	struct rb_node *tmp1, *tmp2, *tmp3;
+	struct artist *artist;
+	struct album *album;
+	struct tree_track *tree_track;
+
+	rb_for_each_entry(artist, tmp1, &lib_artist_root, tree_node) {
+		rb_for_each_entry(album, tmp2, &artist->album_root, tree_node) {
+			rb_for_each_entry(tree_track, tmp3, &album->track_root, tree_node) {
+				struct tree_track_list *tmp = tree_track_list;
+				tree_track_list = xnew(struct tree_track_list, 1);
+				*tree_track_list = (struct tree_track_list){.next = tmp, .track = tree_track};
+			}
+		}
+	}
+
+	while (lib_artist_root.rb_node != NULL) {
+		rb_erase(lib_artist_root.rb_node, &lib_artist_root);
+	}
+
+	window_set_contents(lib_tree_win, &lib_artist_root);
+
+	while (tree_track_list != NULL) {
+		tree_track = tree_track_list->track;
+
+		/* we're leaking the album and artist memory here */
+		tree_add_track(tree_track);
+
+		struct tree_track_list *next = tree_track_list->next;
+		free(tree_track_list);
+		tree_track_list = next;
+	}
+
+	window_set_contents(lib_tree_win, &lib_artist_root);
+}
+
+static void set_composer_as_artist(void *data, const char *buf)
+{
+	bool old_composer_as_artist = composer_as_artist;
+	if (!parse_bool(buf, &composer_as_artist))
+		return;
+	if (old_composer_as_artist != composer_as_artist)
+		rebuild_tree();
+}
+
+static void toggle_composer_as_artist(void *data)
+{
+	composer_as_artist ^= 1;
+	rebuild_tree();
+}
+
 static void get_lib_add_filter(void *data, char *buf, size_t size)
 {
 	strscpy(buf, lib_add_filter ? lib_add_filter : "", size);
@@ -1357,6 +1421,7 @@ static const struct {
 	DT(mouse)
 	DT(mpris)
 	DT(time_show_leading_zero)
+	DT(composer_as_artist)
 	DN(lib_add_filter)
 	DN(start_view)
 	{ NULL, NULL, NULL, NULL, 0 }

--- a/options.h
+++ b/options.h
@@ -142,6 +142,7 @@ extern int skip_track_info;
 extern int mouse;
 extern int mpris;
 extern int time_show_leading_zero;
+extern int composer_as_artist;
 extern int start_view;
 
 extern const char * const aaa_mode_names[];

--- a/track_info.c
+++ b/track_info.c
@@ -79,6 +79,7 @@ void track_info_set_comments(struct track_info *ti, struct keyval *comments) {
 	ti->albumsort = keyvals_get_val(comments, "albumsort");
 	ti->is_va_compilation = track_is_va_compilation(comments);
 	ti->media = keyvals_get_val(comments, "media");
+	ti->composer = keyvals_get_val(comments, "composer");
 
 	int bpm = comments_get_int(comments, "bpm");
 	if (ti->bpm == 0 || ti->bpm == -1) {

--- a/track_info.h
+++ b/track_info.h
@@ -55,6 +55,7 @@ struct track_info {
 	const char *artistsort;
 	const char *albumsort;
 	const char *media;
+	const char *composer;
 
 	char *collkey_artist;
 	char *collkey_album;

--- a/tree.c
+++ b/tree.c
@@ -914,6 +914,20 @@ static void remove_artist(struct artist *artist)
 	rb_erase(&artist->tree_node, &lib_artist_root);
 }
 
+static const char* effective_tree_artist_name(const struct track_info *ti) {
+    if (composer_as_artist && ti->composer != NULL && strcmp(ti->composer, "") != 0)
+	return ti->composer;
+    else
+	return tree_artist_name(ti);
+}
+
+static const char* effective_artistsort_name(const struct track_info *ti) {
+    if (composer_as_artist && ti->composer != NULL && strcmp(ti->composer, "") != 0)
+	return ti->composer;
+    else
+	return ti->artistsort;
+}
+
 void tree_add_track(struct tree_track *track)
 {
 	const struct track_info *ti = tree_track_info(track);
@@ -933,8 +947,8 @@ void tree_add_track(struct tree_track *track)
 		album_name = "<Stream>";
 	} else {
 		album_name	= tree_album_name(ti);
-		artist_name	= tree_artist_name(ti);
-		artistsort_name	= ti->artistsort;
+		artist_name	= effective_tree_artist_name(ti);
+		artistsort_name	= effective_artistsort_name(ti);
 		albumsort_name	= ti->albumsort;
 
 		is_va_compilation = ti->is_va_compilation;


### PR DESCRIPTION
which uses a track's composer tag in place of artist if it exists

This allows the tree view to be organized by composer.

Is there a nicer way to do rebuild_tree?

This addresses issue #612.