### PR TITLE
Added C-n/C-p for history navigation

### DIFF
--- a/command_mode.c
+++ b/command_mode.c
@@ -2909,6 +2909,12 @@ void command_mode_ch(uchar ch)
 		}
 		input_mode = NORMAL_MODE;
 		break;
+	case 0x10: // ^P
+		command_mode_key(KEY_UP);
+		return;
+	case 0xE: // ^N
+		command_mode_key(KEY_DOWN);
+		return;
 	case 0x0A:
 		if (cmdline.blen) {
 			run_command(cmdline.line);

--- a/search_mode.c
+++ b/search_mode.c
@@ -178,6 +178,12 @@ void search_mode_ch(uchar ch)
 	case 0x0B:
 		cmdline_clear_end();
 		break;
+	case 0x10: // ^P
+		search_mode_key(KEY_UP);
+		return;
+	case 0xE: // ^N
+		search_mode_key(KEY_DOWN);
+		return;
 	case 0x15:
 		cmdline_backspace_to_bol();
 		break;


### PR DESCRIPTION
Resolves #482. `C-p/C-n` in command mode and search mode now act like the Up/Down arrow keys, respectively.