### PR TITLE
Add pattern matching for add command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ mpris.o: CFLAGS += $(LIBSYSTEMD_CFLAGS)
 cmus-y := \
 	ape.o browser.o buffer.o cache.o channelmap.o cmdline.o cmus.o command_mode.o \
 	comment.o convert.lo cue.o cue_utils.o debug.o discid.o editable.o expr.o \
-	filters.o format_print.o gbuf.o glob.o help.o history.o http.o id3.o input.o \
+	filters.o format_print.o gbuf.o xglob.o help.o history.o http.o id3.o input.o \
 	job.o keys.o keyval.o lib.o load_dir.o locking.o mergesort.o misc.o options.o \
 	output.o pcm.o player.o play_queue.o pl.o rbtree.o read_wrapper.o search_mode.o \
 	search.o server.o spawn.o tabexp_file.o tabexp.o track_info.o track.o tree.o \

--- a/cmus.h
+++ b/cmus.h
@@ -29,7 +29,8 @@ enum file_type {
 	FILE_TYPE_PL,
 	FILE_TYPE_DIR,
 	FILE_TYPE_FILE,
-	FILE_TYPE_CDDA
+	FILE_TYPE_CDDA,
+	FILE_TYPE_GLOB
 };
 
 typedef int (*track_info_cb)(void *data, struct track_info *ti);

--- a/command_mode.c
+++ b/command_mode.c
@@ -2030,27 +2030,27 @@ static int filter_supported(const char *name, const struct stat *s)
 
 static void expand_files(const char *str)
 {
-	expand_files_and_dirs(str, filter_any);
+	expand_files_and_dirs(str, filter_any, 0);
 }
 
 static void expand_directories(const char *str)
 {
-	expand_files_and_dirs(str, filter_directories);
+	expand_files_and_dirs(str, filter_directories, 0);
 }
 
 static void expand_playable(const char *str)
 {
-	expand_files_and_dirs(str, filter_playable);
+	expand_files_and_dirs(str, filter_playable, 0);
 }
 
 static void expand_playlist(const char *str)
 {
-	expand_files_and_dirs(str, filter_playlist);
+	expand_files_and_dirs(str, filter_playlist, 0);
 }
 
 static void expand_supported(const char *str)
 {
-	expand_files_and_dirs(str, filter_supported);
+	expand_files_and_dirs(str, filter_supported, TABEXP_GLOB);
 }
 
 static void expand_add(const char *str)

--- a/expr.c
+++ b/expr.c
@@ -17,7 +17,7 @@
  */
 
 #include "expr.h"
-#include "glob.h"
+#include "xglob.h"
 #include "uchar.h"
 #include "track_info.h"
 #include "comment.h"

--- a/format_print.c
+++ b/format_print.c
@@ -18,7 +18,7 @@
 
 #include "format_print.h"
 #include "expr.h"
-#include "glob.h"
+#include "xglob.h"
 #include "utils.h"
 #include "options.h"
 #include "uchar.h"

--- a/misc.c
+++ b/misc.c
@@ -150,6 +150,36 @@ const char *unescape(const char *str)
 	return buf;
 }
 
+/* prepends glob metacharacters '[]*?' with a backslash */
+const char *escape_glob(const char *str)
+{
+	static char *buf = NULL;
+	static size_t alloc = 0;
+	size_t len = strlen(str);
+	size_t need = len * 2 + 1;
+	int s, d;
+
+	if (need > alloc) {
+		alloc = (need + 16) & ~(16 - 1);
+		buf = xrealloc(buf, alloc);
+	}
+
+	d = 0;
+	for (s = 0; str[s]; s++) {
+		if (str[s] == '[' || str[s] == ']' ||
+		    str[s] == '*' || str[s] == '?') {
+			buf[d++] = '\\';
+			buf[d++] = str[s];
+			continue;
+		}
+
+		buf[d++] = str[s];
+	}
+	buf[d] = 0;
+	return buf;
+}
+
+
 static int dir_exists(const char *dirname)
 {
 	DIR *dir;

--- a/misc.h
+++ b/misc.h
@@ -35,6 +35,7 @@ int strptrcoll(const void *a, const void *b);
 int misc_init(void);
 const char *escape(const char *str);
 const char *unescape(const char *str);
+const char *escape_glob(const char *str);
 const char *get_filename(const char *path);
 
 /*

--- a/tabexp_file.h
+++ b/tabexp_file.h
@@ -21,8 +21,13 @@
 
 #include <sys/stat.h>
 
+enum tabexp_flags {
+	TABEXP_GLOB = 1 << 0,
+};
+
 void expand_files_and_dirs(const char *src,
-		int (*filter)(const char *name, const struct stat *s));
+		int (*filter)(const char *name, const struct stat *s),
+		int flags);
 void expand_env_path(const char *src,
 		int (*filter)(const char *name, const struct stat *s));
 

--- a/xglob.c
+++ b/xglob.c
@@ -16,7 +16,7 @@
  * along with this program; if not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "glob.h"
+#include "xglob.h"
 #include "uchar.h"
 #include "list.h"
 #include "xmalloc.h"

--- a/xglob.h
+++ b/xglob.h
@@ -16,8 +16,8 @@
  * along with this program; if not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CMUS_GLOB_H
-#define CMUS_GLOB_H
+#ifndef CMUS_XGLOB_H
+#define CMUS_XGLOB_H
 
 #include "list.h"
 


### PR DESCRIPTION
Resolves #659 with glob patterns. Some examples:
- `:add ~/Music/*.mp3`
- `:add ~/Music/*/*.flac`
- `:add ~/Music/*[Rr]adiohead*`
- `:add ~/Music/?.wav`

Calling `:add` on a file that contains glob metacharacters `[]?*` in its filename must now be escaped:
- `:add ~/Music/[2004] Sung Tongs` &rarr;  `:add ~/Music/\[2004\] Sung Tongs`

Tab completion for `:add` has been modified to escape tab-expanded filenames.