### PR TITLE
Fix MPRIS CanGoPrevious property typo

### DIFF
--- a/mpris.c
+++ b/mpris.c
@@ -437,7 +437,7 @@ static const sd_bus_vtable media_player2_player_vt[] = {
 	MPRIS_PROP("MinimumRate", "d", mpris_rate),
 	MPRIS_PROP("MaximumRate", "d", mpris_rate),
 	MPRIS_PROP("CanGoNext", "b", mpris_read_true),
-	MPRIS_PROP("CanGoPrev", "b", mpris_read_true),
+	MPRIS_PROP("CanGoPrevious", "b", mpris_read_true),
 	MPRIS_PROP("CanPlay", "b", mpris_read_true),
 	MPRIS_PROP("CanPause", "b", mpris_read_true),
 	MPRIS_PROP("CanSeek", "b", mpris_read_true),


### PR DESCRIPTION
Rename MPRIS property `CanGoPrev` to `CanGoPrevious` in accordance with the [spec](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:CanGoPrevious).