### PR TITLE
:clear playlist even when in track window

### DIFF
--- a/pl.c
+++ b/pl.c
@@ -727,9 +727,6 @@ void pl_rename_selected_pl(const char *name)
 
 void pl_clear(void)
 {
-	if (!pl_cursor_in_track_window)
-		return;
-
 	pl_clear_visible_pl();
 }
 


### PR DESCRIPTION
`:clear` does nothing if you are in the left window of the playlist view, because the function simply returns.
But the function further called, `pl_clear_visible_pl`, would switch to the right window anyway if you are in the left one, so the return seems to be unneccesary.

Currently this makes it really hard to clear a playlist from `cmus-remote` because you never know if you are in the right window, at least I found no command to determine which window the cursor currently is in.