### PR TITLE
Fix depfile generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,7 @@ all: main plugins man
 -include config.mk
 include scripts/lib.mk
 
-# $(topdir) must be included at the earliest possible stage, to avoid
-# conflicts with system headers.
-CFLAGS := -I"$(topdir)" -D_FILE_OFFSET_BITS=64 $(CFLAGS)
+CFLAGS += -D_FILE_OFFSET_BITS=64
 
 FFMPEG_CFLAGS += $(shell pkg-config --cflags libswresample)
 FFMPEG_LIBS += $(shell pkg-config --libs libswresample)

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -172,7 +172,7 @@ check_cc()
 	check_program $CC || return 1
 
 	cc_cxx_common
-	CFLAGS="$CFLAGS $common_cf"
+	CFLAGS="$CFLAGS -I$(pwd) $common_cf"
 	LDFLAGS="$LDFLAGS $common_lf"
 
 	makefile_vars CC LD CFLAGS LDFLAGS


### PR DESCRIPTION
a4540236 broke lazy expansion of -dep-$@ in CFLAGS by performing an :=
assignment of CFLAGS in the Makefile.