### PR TITLE
Fix #574 (deadlocks in player.c)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ cmus-y := \
 	job.o keys.o keyval.o lib.o load_dir.o locking.o mergesort.o misc.o options.o \
 	output.o pcm.o player.o play_queue.o pl.o rbtree.o read_wrapper.o search_mode.o \
 	search.o server.o spawn.o tabexp_file.o tabexp.o track_info.o track.o tree.o \
-	uchar.o u_collate.o ui_curses.o window.o worker.o xstrjoin.o
+	uchar.o u_collate.o ui_curses.o window.o worker.o xstrjoin.o delegate.o
 
 cmus-$(CONFIG_MPRIS) += mpris.o
 

--- a/delegate.c
+++ b/delegate.c
@@ -1,0 +1,75 @@
+#include "debug.h"
+#include "locking.h"
+#include "delegate.h"
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+static pthread_t delegate_thread;
+static pthread_mutex_t delegate_mutex = CMUS_MUTEX_INITIALIZER;
+static pthread_cond_t delegate_cond = CMUS_COND_INITIALIZER;
+
+static struct delegate_args_header *delegate_first;
+static struct delegate_args_header *delegate_last;
+
+static bool delegate_stop = false;
+
+static void *delegate_loop(void *arg)
+{
+	cmus_mutex_lock(&delegate_mutex);
+
+	while (true) {
+		struct delegate_args_header *prev, *cmd = delegate_first;
+		delegate_first = delegate_last = NULL;
+
+		cmus_mutex_unlock(&delegate_mutex);
+
+		while (cmd) {
+			cmd->handler(cmd);
+			prev = cmd;
+			cmd = cmd->next;
+			free(prev);
+		}
+
+		cmus_mutex_lock(&delegate_mutex);
+
+		if (delegate_stop)
+			break;
+		if (!delegate_first)
+			pthread_cond_wait(&delegate_cond, &delegate_mutex);
+	}
+
+	cmus_mutex_unlock(&delegate_mutex);
+
+	return NULL;
+}
+
+void delegate_init(void)
+{
+	int rc = pthread_create(&delegate_thread, NULL, delegate_loop,
+			NULL);
+	BUG_ON(rc);
+}
+
+void delegate_exit(void)
+{
+	cmus_mutex_lock(&delegate_mutex);
+	delegate_stop = true;
+	cmus_mutex_unlock(&delegate_mutex);
+	pthread_cond_signal(&delegate_cond);
+
+	int rc = pthread_join(delegate_thread, NULL);
+	BUG_ON(rc);
+}
+
+void delegate_add_cmd(struct delegate_args_header *header)
+{
+	cmus_mutex_lock(&delegate_mutex);
+	if (delegate_last)
+		delegate_last->next = header;
+	else
+		delegate_first = delegate_last = header;
+	cmus_mutex_unlock(&delegate_mutex);
+
+	pthread_cond_signal(&delegate_cond);
+}

--- a/delegate.h
+++ b/delegate.h
@@ -1,0 +1,86 @@
+#ifndef PLAYER_DELEGATE_H
+#define PLAYER_DELEGATE_H
+
+struct delegate_args_header {
+	void *next;
+	void (*handler)(void *);
+};
+
+void delegate_init(void);
+void delegate_exit(void);
+void delegate_add_cmd(struct delegate_args_header *header);
+
+#define DELEGATE_FN(fn, ...) \
+	struct delegate_args_##fn *args = xmalloc(sizeof(*args)); \
+	*args = (struct delegate_args_##fn) { \
+		{ NULL, delegate_handler_##fn }, ##__VA_ARGS__ \
+	}; \
+	delegate_add_cmd(&args->header); \
+
+#define DELEGATE_0(fn) \
+	struct delegate_args_##fn { \
+		struct delegate_args_header header; \
+	}; \
+	static void delegate_impl_##fn(void); \
+	static void delegate_handler_##fn(void *vargs) \
+	{ \
+		delegate_impl_##fn(); \
+	} \
+	void fn(void) \
+	{ \
+		DELEGATE_FN(fn) \
+	} \
+	static void delegate_impl_##fn(void)
+
+#define DELEGATE_1(fn, type1, name1) \
+	struct delegate_args_##fn { \
+		struct delegate_args_header header; \
+		type1 a1; \
+	}; \
+	static void delegate_impl_##fn(type1 name1); \
+	static void delegate_handler_##fn(void *vargs) \
+	{ \
+		struct delegate_args_##fn *args = vargs; \
+		delegate_impl_##fn(args->a1); \
+	} \
+	void fn(type1 a1) \
+	{ \
+		DELEGATE_FN(fn, a1) \
+	} \
+	static void delegate_impl_##fn(type1 name1)
+
+#define DELEGATE_2(fn, type1, name1, type2, name2) \
+	struct delegate_args_##fn { \
+		struct delegate_args_header header; \
+		type1 a1; type2 a2; \
+	}; \
+	static void delegate_impl_##fn(type1 name1, type2 name2); \
+	static void delegate_handler_##fn(void *vargs) \
+	{ \
+		struct delegate_args_##fn *args = vargs; \
+		delegate_impl_##fn(args->a1, args->a2); \
+	} \
+	void fn(type1 a1, type2 a2) \
+	{ \
+		DELEGATE_FN(fn, a1, a2) \
+	} \
+	static void delegate_impl_##fn(type1 name1, type2 name2)
+
+#define DELEGATE_3(fn, type1, name1, type2, name2, type3, name3) \
+	struct delegate_args_##fn { \
+		struct delegate_args_header header; \
+		type1 a1; type2 a2; type3 a3; \
+	}; \
+	static void delegate_impl_##fn(type1 name1, type2 name2, type3 name3); \
+	static void delegate_handler_##fn(void *vargs) \
+	{ \
+		struct delegate_args_##fn *args = vargs; \
+		delegate_impl_##fn(args->a1, args->a2, args->a3); \
+	} \
+	void fn(type1 a1, type2 a2, type3 a3) \
+	{ \
+		DELEGATE_FN(fn, a1, a2, a3) \
+	} \
+	static void delegate_impl_##fn(type1 name1, type2 name2, type3 name3)
+
+#endif

--- a/options.c
+++ b/options.c
@@ -377,7 +377,7 @@ static void set_output_plugin(void *data, const char *buf)
 	if (ui_initialized) {
 		if (!soft_vol)
 			mixer_close();
-		player_set_op(buf);
+		player_set_op(xstrdup(buf));
 		if (!soft_vol)
 			mixer_open();
 	} else {

--- a/player.c
+++ b/player.c
@@ -27,7 +27,6 @@
 #include "debug.h"
 #include "compiler.h"
 #include "options.h"
-#include "mpris.h"
 #include "cmus.h"
 
 #include <stdio.h>
@@ -1289,8 +1288,11 @@ void player_seek(double offset, int relative, int start_playing)
 			d_print("error: ip_seek returned %d\n", rc);
 		}
 	}
-	mpris_seeked();
 	player_unlock();
+
+	player_info_priv_lock();
+	player_info_priv.seeked = 1;
+	player_info_priv_unlock();
 }
 
 /*
@@ -1466,6 +1468,7 @@ void player_info_snapshot(void)
 	player_info_priv.status_changed = 0;
 	player_info_priv.position_changed = 0;
 	player_info_priv.buffer_fill_changed = 0;
+	player_info_priv.seeked = 0;
 	player_info_priv.error_msg = NULL;
 
 	player_info_priv_unlock();

--- a/player.c
+++ b/player.c
@@ -1296,7 +1296,7 @@ void player_seek(double offset, int relative, int start_playing)
 /*
  * change output plugin without stopping playback
  */
-void player_set_op(const char *name)
+void player_set_op(char *name)
 {
 	int rc;
 
@@ -1325,8 +1325,7 @@ void player_set_op(const char *name)
 			player_op_error(rc, "selecting output plugin '%s'", name);
 		else
 			player_op_error(rc, "selecting any output plugin");
-		player_unlock();
-		return;
+		goto out;
 	}
 
 	if (consumer_status == CS_PLAYING || consumer_status == CS_PAUSED) {
@@ -1336,13 +1335,14 @@ void player_set_op(const char *name)
 			_consumer_status_update(CS_STOPPED);
 			_producer_stop();
 			player_op_error(rc, "opening audio device");
-			player_unlock();
-			return;
+			goto out;
 		}
 		if (consumer_status == CS_PAUSED)
 			op_pause();
 	}
 
+out:
+	free(name);
 	player_unlock();
 }
 

--- a/player.c
+++ b/player.c
@@ -28,6 +28,7 @@
 #include "compiler.h"
 #include "options.h"
 #include "cmus.h"
+#include "delegate.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -1076,7 +1077,7 @@ void player_exit(void)
 	buffer_free();
 }
 
-void player_stop(void)
+DELEGATE_0(player_stop)
 {
 	player_lock();
 	_consumer_stop();
@@ -1085,7 +1086,7 @@ void player_stop(void)
 	player_unlock();
 }
 
-void player_play(void)
+DELEGATE_0(player_play)
 {
 	int prebuffer;
 
@@ -1110,7 +1111,7 @@ void player_play(void)
 	player_unlock();
 }
 
-void player_pause(void)
+DELEGATE_0(player_pause)
 {
 	if (ip && ip_is_remote(ip) && consumer_status == CS_PLAYING) {
 		/* pausing not allowed */
@@ -1139,13 +1140,13 @@ void player_pause(void)
 	player_unlock();
 }
 
-void player_pause_playback(void)
+DELEGATE_0(player_pause_playback)
 {
 	if (consumer_status == CS_PLAYING)
 		player_pause();
 }
 
-void player_set_file(struct track_info *ti)
+DELEGATE_1(player_set_file, struct track_info *, ti)
 {
 	player_lock();
 	_producer_set_file(ti);
@@ -1171,7 +1172,7 @@ out:
 	player_unlock();
 }
 
-void player_play_file(struct track_info *ti)
+DELEGATE_1(player_play_file, struct track_info *, ti)
 {
 	player_lock();
 	_producer_set_file(ti);
@@ -1210,7 +1211,7 @@ void player_file_changed(struct track_info *ti)
 	_file_changed(ti);
 }
 
-void player_seek(double offset, int relative, int start_playing)
+DELEGATE_3(player_seek, double, offset, int, relative, int, start_playing)
 {
 	int stopped = 0;
 	player_lock();
@@ -1298,7 +1299,7 @@ void player_seek(double offset, int relative, int start_playing)
 /*
  * change output plugin without stopping playback
  */
-void player_set_op(char *name)
+DELEGATE_1(player_set_op, char *, name)
 {
 	int rc;
 
@@ -1348,7 +1349,7 @@ out:
 	player_unlock();
 }
 
-void player_set_buffer_chunks(unsigned int nr_chunks)
+DELEGATE_1(player_set_buffer_chunks, unsigned int, nr_chunks)
 {
 	player_lock();
 	_producer_stop();
@@ -1366,7 +1367,7 @@ int player_get_buffer_chunks(void)
 	return buffer_nr_chunks;
 }
 
-void player_set_soft_volume(int l, int r)
+DELEGATE_2(player_set_soft_volume, int, l, int, r)
 {
 	consumer_lock();
 	soft_vol_l = l;
@@ -1374,7 +1375,7 @@ void player_set_soft_volume(int l, int r)
 	consumer_unlock();
 }
 
-void player_set_soft_vol(int soft)
+DELEGATE_1(player_set_soft_vol, int, soft)
 {
 	consumer_lock();
 	/* don't mess with scale_pos if soft_vol or replaygain is already enabled */
@@ -1413,7 +1414,7 @@ int player_set_vol(int l, int lf, int r, int rf)
 	return rc;
 }
 
-void player_set_rg(enum replaygain rg)
+DELEGATE_1(player_set_rg, enum replaygain, rg)
 {
 	player_lock();
 	/* don't mess with scale_pos if soft_vol or replaygain is already enabled */
@@ -1428,7 +1429,7 @@ void player_set_rg(enum replaygain rg)
 	player_unlock();
 }
 
-void player_set_rg_limit(int limit)
+DELEGATE_1(player_set_rg_limit, int, limit)
 {
 	player_lock();
 	replaygain_limit = limit;
@@ -1440,7 +1441,7 @@ void player_set_rg_limit(int limit)
 	player_unlock();
 }
 
-void player_set_rg_preamp(double db)
+DELEGATE_1(player_set_rg_preamp, double, db)
 {
 	player_lock();
 	replaygain_preamp = db;

--- a/player.h
+++ b/player.h
@@ -99,7 +99,7 @@ void player_stop(void);
 void player_pause(void);
 void player_pause_playback(void);
 void player_seek(double offset, int relative, int start_playing);
-void player_set_op(const char *name);
+void player_set_op(char *name);
 void player_set_buffer_chunks(unsigned int nr_chunks);
 int player_get_buffer_chunks(void);
 void player_info_snapshot(void);

--- a/player.h
+++ b/player.h
@@ -69,6 +69,7 @@ struct player_info {
 	unsigned int status_changed : 1;
 	unsigned int position_changed : 1;
 	unsigned int buffer_fill_changed : 1;
+	unsigned int seeked : 1;
 };
 
 extern char player_metadata[255 * 16 + 1];

--- a/ui_curses.c
+++ b/ui_curses.c
@@ -51,6 +51,7 @@
 #include "mixer.h"
 #include "mpris.h"
 #include "locking.h"
+#include "delegate.h"
 #ifdef HAVE_CONFIG
 #include "config/curses.h"
 #include "config/iconv.h"
@@ -2368,6 +2369,7 @@ static void init_all(void)
 	cmdline_init();
 	commands_init();
 	search_mode_init();
+	delegate_init();
 
 	/* almost everything must be initialized now */
 	options_load();
@@ -2414,6 +2416,7 @@ static void exit_all(void)
 {
 	endwin();
 
+	delegate_exit();
 	if (resume_cmus)
 		resume_exit();
 	options_exit();

--- a/ui_curses.c
+++ b/ui_curses.c
@@ -1953,6 +1953,9 @@ static void update(void)
 	if (player_info.status_changed)
 		mpris_playback_status_changed();
 
+	if (player_info.seeked)
+		mpris_seeked();
+
 	if (player_info.file_changed || player_info.metadata_changed)
 		mpris_metadata_changed();
 

--- a/ui_curses.c
+++ b/ui_curses.c
@@ -2377,7 +2377,10 @@ static void init_all(void)
 		mpris_init();
 
 	/* finally we can set the output plugin */
-	player_set_op(output_plugin);
+	if (output_plugin)
+		player_set_op(xstrdup(output_plugin));
+	else
+		player_set_op(NULL);
 	if (!soft_vol)
 		mixer_open();
 


### PR DESCRIPTION
Tl;dr: The UI thread no longer waits for the player to perform its requests (player_next, etc.) Instead it simply schedules the commands and returns immediately. This allows the UI thread to reply to `cmus_get_next` requests that occur while the player holds its locks.

Fixes #574.