### PR TITLE
Remove double-inclusion of stdatomic header

### DIFF
--- a/track_info.c
+++ b/track_info.c
@@ -30,7 +30,6 @@
 #include <string.h>
 #include <stdatomic.h>
 #include <math.h>
-#include <stdatomic.h>
 
 struct track_info_priv {
 	struct track_info ti;


### PR DESCRIPTION
Just a really teeny fix: `track_info.c` accidentally included `stdatomic.h` twice, and now it doesn't.