### PR TITLE
Make ^U/^D default for half-page up/down motions

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -697,10 +697,10 @@ win-bottom (*G*, *end*)
 win-down [NUM] (*j*, *down*)
 	Goto down NUM (default 1) rows in the current window.
 
-win-half-page-down
+win-half-page-down (*^D*)
 	Goto down half a page in the current window.
 
-win-half-page-up
+win-half-page-up (*^U*)
 	Goto up half a page in the current window.
 
 win-mv-after (*p*)

--- a/data/rc
+++ b/data/rc
@@ -33,9 +33,11 @@ bind common P win-mv-before
 bind common [ vol +1% +0
 bind common ] vol +0 +1%
 bind common ^B win-page-up
+bind common ^U win-half-page-up
 bind common ^C echo Type :quit<enter> to exit cmus.
 bind common ^E win-scroll-down
 bind common ^F win-page-down
+bind common ^D win-half-page-down
 bind common ^L refresh
 bind common ^R toggle repeat_current
 bind common ^Y win-scroll-up


### PR DESCRIPTION
By default vim binds `^U` and `^D` to half-page up/down, so cmus should as well.