### PR TITLE
Fade on pause/unpause

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -946,6 +946,11 @@ display_artist_sort_name (false)
 	regular ones in tree view (e.g. "Artist, The" instead of "The Artist"),
 	so that artists column looks alphabetically sorted.
 
+fade_duration (0)
+	Fade output when pausing/unpausing. Duration is in milliseconds.
+
+	NOTE: has no effect if output_plugin doesn't support volume control.
+
 follow (false)
 	If enabled, always select the currently playing track on track change.
 

--- a/options.c
+++ b/options.c
@@ -84,7 +84,7 @@ int mouse = 0;
 int mpris = 1;
 int time_show_leading_zero = 1;
 int start_view = TREE_VIEW;
-int fade_duration = 100;
+int fade_duration = 0;
 
 int colors[NR_COLORS] = {
 	-1,

--- a/options.c
+++ b/options.c
@@ -84,6 +84,7 @@ int mouse = 0;
 int mpris = 1;
 int time_show_leading_zero = 1;
 int start_view = TREE_VIEW;
+int fade_duration = 100;
 
 int colors[NR_COLORS] = {
 	-1,
@@ -1175,6 +1176,19 @@ static void set_start_view(void *data, const char *buf)
 	}
 }
 
+static void get_fade_duration(void *data, char *buf, size_t size)
+{
+	buf_int(buf, fade_duration, size);
+}
+
+static void set_fade_duration(void *data, const char *buf)
+{
+	int offset;
+
+	if (parse_int(buf, 0, 1000, &offset))
+		fade_duration = offset;
+}
+
 static void get_attr(void *data, char *buf, size_t size)
 {
 	int attr = *(int *)data;
@@ -1364,6 +1378,7 @@ static const struct {
 	DT(time_show_leading_zero)
 	DN(lib_add_filter)
 	DN(start_view)
+	DN(fade_duration)
 	{ NULL, NULL, NULL, NULL, 0 }
 };
 

--- a/options.h
+++ b/options.h
@@ -147,6 +147,7 @@ extern int mouse;
 extern int mpris;
 extern int time_show_leading_zero;
 extern int start_view;
+extern int fade_duration;
 
 extern const char * const aaa_mode_names[];
 extern const char * const view_names[NR_VIEWS + 1];

--- a/output.c
+++ b/output.c
@@ -63,6 +63,9 @@ int volume_max = 0;
 int volume_l = -1;
 int volume_r = -1;
 
+#define FADE_STEP_MSEC 10
+static int fade_initial_l, fade_initial_r;
+
 static void add_plugin(struct output_plugin *plugin)
 {
 	struct list_head *item = op_head.next;
@@ -332,9 +335,6 @@ bool mixer_fade_enabled(void)
 	return op != NULL && op->mixer_open && fade_duration > 0;
 }
 
-#define FADE_STEP_MSEC 10
-
-int fade_initial_l, fade_initial_r;
 int mixer_fadeout(void)
 {
 	if ((errno = mixer_read_volume()) != 0) {

--- a/output.c
+++ b/output.c
@@ -337,9 +337,12 @@ bool mixer_fade_enabled(void)
 
 int mixer_fadeout(void)
 {
-	if ((errno = mixer_read_volume()) != 0) {
-		return errno;
-	}
+	int rc;
+
+	rc = mixer_read_volume();
+	if (rc)
+		return rc;
+
 	fade_initial_l = volume_l;
 	fade_initial_r = volume_r;
 
@@ -365,9 +368,12 @@ int mixer_fadeout_end(void)
 
 int mixer_fadein(void)
 {
-	if ((errno = mixer_read_volume()) != 0) {
-		return errno;
-	}
+	int rc;
+
+	rc = mixer_read_volume();
+	if (rc)
+		return rc;
+
 	fade_initial_l = volume_l;
 	fade_initial_r = volume_r;
 	return mixer_set_volume(0, 0);

--- a/output.c
+++ b/output.c
@@ -335,6 +335,23 @@ bool mixer_fade_enabled(void)
 	return op != NULL && op->mixer_open && fade_duration >= FADE_STEP_MSEC;
 }
 
+static int mixer_fade(int from_l, int from_r, int to_l, int to_r)
+{
+	int fade_steps = fade_duration / FADE_STEP_MSEC;
+	int l_step_size = (to_l - from_l) / fade_steps;
+	int r_step_size = (to_r - from_r) / fade_steps;
+
+	int l = from_l, r = from_r;
+	for (int i = 0; i < fade_steps; i++) {
+		l += l_step_size;
+		r += r_step_size;
+		mixer_set_volume(l, r);
+		ms_sleep(FADE_STEP_MSEC);
+	}
+
+	return mixer_set_volume(to_l, to_r);
+}
+
 int mixer_fadeout(void)
 {
 	int rc;
@@ -345,20 +362,7 @@ int mixer_fadeout(void)
 
 	fade_initial_l = volume_l;
 	fade_initial_r = volume_r;
-
-	int fade_steps = fade_duration / FADE_STEP_MSEC;
-	int l_step_size = fade_initial_l / fade_steps;
-	int r_step_size = fade_initial_r / fade_steps;
-
-	int l = fade_initial_l, r = fade_initial_r;
-	for (int i = 0; i < fade_steps; i++) {
-		l -= l_step_size;
-		r -= r_step_size;
-		mixer_set_volume(l, r);
-		ms_sleep(FADE_STEP_MSEC);
-	}
-
-	return mixer_set_volume(0, 0);
+	return mixer_fade(volume_l, volume_r, 0, 0);
 }
 
 int mixer_fadeout_end(void)
@@ -381,19 +385,7 @@ int mixer_fadein(void)
 
 int mixer_fadein_end(void)
 {
-	int fade_steps = fade_duration / FADE_STEP_MSEC;
-	int l_step_size = fade_initial_l / fade_steps;
-	int r_step_size = fade_initial_r / fade_steps;
-
-	int l = 0, r = 0;
-	for (int i = 0; i < fade_steps; i++) {
-		l += l_step_size;
-		r += r_step_size;
-		mixer_set_volume(l, r);
-		ms_sleep(FADE_STEP_MSEC);
-	}
-
-	return mixer_set_volume(fade_initial_l, fade_initial_r);
+	return mixer_fade(0, 0, fade_initial_l, fade_initial_r);
 }
 
 extern int soft_vol;

--- a/output.c
+++ b/output.c
@@ -332,7 +332,7 @@ int mixer_get_fds(int *fds)
 
 bool mixer_fade_enabled(void)
 {
-	return op != NULL && op->mixer_open && fade_duration > 0;
+	return op != NULL && op->mixer_open && fade_duration >= FADE_STEP_MSEC;
 }
 
 int mixer_fadeout(void)

--- a/output.h
+++ b/output.h
@@ -22,6 +22,8 @@
 #include "sf.h"
 #include "channelmap.h"
 
+#include <stdbool.h>
+
 extern int volume_max;
 extern int volume_l;
 extern int volume_r;
@@ -86,6 +88,11 @@ void mixer_close(void);
 int mixer_set_volume(int left, int right);
 int mixer_read_volume(void);
 int mixer_get_fds(int *fds);
+bool mixer_fade_enabled(void);
+int mixer_fadeout(void);
+int mixer_fadeout_end(void);
+int mixer_fadein(void);
+int mixer_fadein_end(void);
 
 void op_add_options(void);
 char *op_get_error_msg(int rc, const char *arg);

--- a/player.c
+++ b/player.c
@@ -1122,13 +1122,11 @@ void player_pause(void)
 	bool fade_enabled = mixer_fade_enabled();
 	if (fade_enabled) {
 		if (consumer_status == CS_PAUSED) {
-			if (mixer_fadein() != 0) {
+			if (mixer_fadein())
 				fade_enabled = false;
-			}
 		} else {
-			if (mixer_fadeout() != 0) {
+			if (mixer_fadeout())
 				fade_enabled = false;
-			}
 		}
 	}
 
@@ -1154,11 +1152,10 @@ void player_pause(void)
 	player_unlock();
 
 	if (fade_enabled) {
-		if (consumer_status == CS_PLAYING) {
+		if (consumer_status == CS_PLAYING)
 			mixer_fadein_end();
-		} else {
+		else
 			mixer_fadeout_end();
-		}
 	}
 }
 

--- a/player.c
+++ b/player.c
@@ -1118,6 +1118,20 @@ void player_pause(void)
 		player_stop();
 		return;
 	}
+
+	bool fade_enabled = mixer_fade_enabled();
+	if (fade_enabled) {
+		if (consumer_status == CS_PAUSED) {
+			if (mixer_fadein() != 0) {
+				fade_enabled = false;
+			}
+		} else {
+			if (mixer_fadeout() != 0) {
+				fade_enabled = false;
+			}
+		}
+	}
+
 	player_lock();
 
 	if (consumer_status == CS_STOPPED) {
@@ -1138,6 +1152,14 @@ void player_pause(void)
 	_consumer_pause();
 	_player_status_changed();
 	player_unlock();
+
+	if (fade_enabled) {
+		if (consumer_status == CS_PLAYING) {
+			mixer_fadein_end();
+		} else {
+			mixer_fadeout_end();
+		}
+	}
 }
 
 void player_pause_playback(void)


### PR DESCRIPTION
I've had a go at adding a fade to pause/unpause (https://github.com/cmus/cmus/issues/221).

It's implemented by adjusting the output's mixer volume. That makes sense for audio interfaces where the volume is for the stream only (ie. PulseAudio, CoreAudio, Roar?). However, if the mixer is actually for the system volume it'll have the side effect of fading other applications. The default fade duration is only 100ms so it might not be a big deal, but I'm interested to get some feedback. It would be easy enough to expose a per-plugin flag that enables fading instead.

I've only tested with PulseAudio so far.