### PR TITLE
Add command to raise VTE window + implement MPRIS Raise method

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -519,6 +519,9 @@ quit [-i] (*q*, *:wq*)
 	@li -i
 	ask before exiting
 
+raise-vte
+	Raise the virtual terminal emulator window.  Works only in X session.
+
 rand
 	Randomizes (shuffles) the tracks in the library, playlist or queue view.
 

--- a/cmus.h
+++ b/cmus.h
@@ -90,4 +90,7 @@ struct track_info *cmus_get_next_track(void);
 void cmus_provide_next_track(void);
 void cmus_track_request_init(void);
 
+int cmus_can_raise_vte(void);
+void cmus_raise_vte(void);
+
 #endif

--- a/command_mode.c
+++ b/command_mode.c
@@ -1374,6 +1374,11 @@ static void cmd_pwd(char *arg)
 	}
 }
 
+static void cmd_raise_vte(char *arg)
+{
+	cmus_raise_vte();
+}
+
 static void cmd_rand(char *arg)
 {
 	switch (cur_view) {
@@ -2551,6 +2556,7 @@ struct command commands[] = {
 	{ "pl-rename",             cmd_pl_rename,        1, -1, NULL,                 0, 0          },
 	{ "push",                  cmd_push,             1, -1, expand_commands,      0, 0          },
 	{ "pwd",                   cmd_pwd,              0, 0,  NULL,                 0, 0          },
+	{ "raise-vte",             cmd_raise_vte,        0, 0,  NULL,                 0, 0          },
 	{ "rand",                  cmd_rand,             0, 0,  NULL,                 0, 0          },
 	{ "quit",                  cmd_quit,             0, 1,  NULL,                 0, 0          },
 	{ "refresh",               cmd_refresh,          0, 0,  NULL,                 0, 0          },

--- a/mpris.c
+++ b/mpris.c
@@ -68,6 +68,22 @@ static int mpris_write_ignore(sd_bus *_bus, const char *_path,
 	return sd_bus_reply_method_return(value, "");
 }
 
+static int mpris_raise_vte(sd_bus_message *m, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	cmus_raise_vte();
+	return sd_bus_reply_method_return(m, "");
+}
+
+static int mpris_can_raise_vte(sd_bus *_bus, const char *_path,
+		const char *_interface, const char *_property,
+		sd_bus_message *reply, void *_userdata,
+		sd_bus_error *_ret_error)
+{
+	uint32_t b = cmus_can_raise_vte();
+	return sd_bus_message_append_basic(reply, 'b', &b);
+}
+
 static int mpris_identity(sd_bus *_bus, const char *_path,
 		const char *_interface, const char *_property,
 		sd_bus_message *reply, void *_userdata,
@@ -404,12 +420,12 @@ static int mpris_metadata(sd_bus *_bus, const char *_path,
 
 static const sd_bus_vtable media_player2_vt[] = {
 	SD_BUS_VTABLE_START(0),
-	SD_BUS_METHOD("Raise", "", "", mpris_msg_ignore, 0),
+	SD_BUS_METHOD("Raise", "", "", mpris_raise_vte, 0),
 	SD_BUS_METHOD("Quit", "", "", mpris_msg_ignore, 0),
 	MPRIS_PROP("CanQuit", "b", mpris_read_false),
 	MPRIS_WPROP("Fullscreen", "b", mpris_read_false, mpris_write_ignore),
 	MPRIS_PROP("CanSetFullscreen", "b", mpris_read_false),
-	MPRIS_PROP("CanRaise", "b", mpris_read_false),
+	MPRIS_PROP("CanRaise", "b", mpris_can_raise_vte),
 	MPRIS_PROP("HasTrackList", "b", mpris_read_false),
 	MPRIS_PROP("Identity", "s", mpris_identity),
 	MPRIS_PROP("SupportedUriSchemes", "as", mpris_uri_schemes),


### PR DESCRIPTION
I've implemented what I described before in https://github.com/cmus/cmus/issues/756.

It detects X11 system, loads `libX11` using `dlopen` and raises the terminal window.

It also adds `raise-vte` command and implements `Raise` method in MPRIS protocol.