### PR TITLE
Correct parsing for cue files with byte order mark

### DIFF
--- a/cue.c
+++ b/cue.c
@@ -485,9 +485,7 @@ struct cue_sheet *cue_from_file(const char *file)
 
 	// Check for UTF-8 BOM, and skip ahead if found
 	if (size >= 3 && memcmp(buf, "\xEF\xBB\xBF", 3) == 0) {
-		ssize_t postbom_size = size - 3;
-		char *postbom_buf = cue_strdup(&buf[3], postbom_size);
-		rv = cue_parse(postbom_buf, postbom_size);
+		rv = cue_parse(buf + 3, size - 3);
 	} else {
 		rv = cue_parse(buf, size);
 	}

--- a/cue.c
+++ b/cue.c
@@ -481,6 +481,11 @@ struct cue_sheet *cue_from_file(const char *file)
 	char *buf = mmap_file(file, &size);
 	if (size == -1)
 		return NULL;
+
+	// ignore BOM
+	if (size >= 3 && memcmp(buf, "\xEF\xBB\xBF", 3) == 0)
+		buf += 3;
+
 	struct cue_sheet *rv = cue_parse(buf, size);
 	munmap(buf, size);
 	return rv;

--- a/cue.c
+++ b/cue.c
@@ -479,10 +479,11 @@ struct cue_sheet *cue_from_file(const char *file)
 {
 	ssize_t size;
 	char *buf = mmap_file(file, &size);
-	bool bom_detected = false;
 
 	if (size == -1)
 		return NULL;
+
+	bool bom_detected = false;
 
 	// ignore BOM
 	if (size >= 3 && memcmp(buf, "\xEF\xBB\xBF", 3) == 0) {

--- a/cue.c
+++ b/cue.c
@@ -479,14 +479,25 @@ struct cue_sheet *cue_from_file(const char *file)
 {
 	ssize_t size;
 	char *buf = mmap_file(file, &size);
+	bool bom_detected = false;
+
 	if (size == -1)
 		return NULL;
 
 	// ignore BOM
-	if (size >= 3 && memcmp(buf, "\xEF\xBB\xBF", 3) == 0)
+	if (size >= 3 && memcmp(buf, "\xEF\xBB\xBF", 3) == 0) {
 		buf += 3;
+		size -= 3;
+		bom_detected = true;
+	}
 
 	struct cue_sheet *rv = cue_parse(buf, size);
+
+	if (bom_detected) {
+		buf -= 3;
+		size += 3;
+	}
+
 	munmap(buf, size);
 	return rv;
 }


### PR DESCRIPTION
Cue files which have a byte order mark are improperly parsed. Currently, if there is a byte order mark present and a valid cue token on the first line of the file, the token is not recognized and the first line of cue data is missed. For my use case, the first line would the the album title, and therefore any cue files in my library would be displayed with `<No Title>` as the album title.

This commit looks for the presence of a UTF-8 byte order mark and advances the file buffer beyond it. In UTF-8, the byte order mark isn't recommended and really serves no purpose other than to signify the beginning of a UTF-8 stream.