### PR TITLE
Fix ffmpeg plugin build

### DIFF
--- a/ip/ffmpeg.c
+++ b/ip/ffmpeg.c
@@ -182,8 +182,8 @@ static int ffmpeg_open(struct input_plugin_data *ip_data)
 			break;
 		}
 
-		if (codec->capabilities & CODEC_CAP_TRUNCATED)
-			cc->flags |= CODEC_FLAG_TRUNCATED;
+		if (codec->capabilities & AV_CODEC_CAP_TRUNCATED)
+			cc->flags |= AV_CODEC_FLAG_TRUNCATED;
 
 		if (avcodec_open2(cc, codec, NULL) < 0) {
 			d_print("could not open codec: %d, %s\n", cc->codec_id, avcodec_get_name(cc->codec_id));


### PR DESCRIPTION
I don't know that much about ffmpeg development, but it seems as if the cmus plugins uses some deprecated constants/symbols that result in build errors with newer ffmpegs (especially fairly recent source builds). This fixes building with newer ffmpeg builds, and also fixes https://github.com/cmus/cmus/issues/782, for example. I don't know yet if cmus wants to support the latest ffmpeg and possibly drop support for older ones, but maybe take this PR into consideration at a new point release. 