### PR TITLE
Accept PARTOFACOMPILATION tag

### DIFF
--- a/comment.c
+++ b/comment.c
@@ -40,6 +40,10 @@ int track_is_compilation(const struct keyval *comments)
 	if (c && is_freeform_true(c))
 		return 1;
 
+	c = keyvals_get_val(comments, "partofacompilation");
+	if (c && is_freeform_true(c))
+		return 1;
+
 	aa = keyvals_get_val(comments, "albumartist");
 	if (aa && is_various_artists(aa))
 		return 1;
@@ -67,6 +71,10 @@ int track_is_va_compilation(const struct keyval *comments)
 		return 1;
 
 	c = keyvals_get_val(comments, "compilation");
+	if (c && is_freeform_true(c))
+		return 1;
+
+	c = keyvals_get_val(comments, "partofacompilation");
 	if (c && is_freeform_true(c))
 		return 1;
 
@@ -176,7 +184,7 @@ int comments_get_date(const struct keyval *comments, const char *key)
 
 static const char *interesting[] = {
 	"artist", "album", "title", "tracknumber", "discnumber", "genre",
-	"date", "compilation", "albumartist", "artistsort", "albumartistsort",
+	"date", "compilation", "partofacompilation", "albumartist", "artistsort", "albumartistsort",
 	"albumsort",
 	"originaldate",
 	"replaygain_track_gain",


### PR DESCRIPTION
I tag my FLAC collection with Meta on macOS:
https://www.nightbirdsevolve.com/meta/

…but compilations don't appear as they should with cmus, because Meta only adds a `PARTOFACOMPILATION=1` tag and no `COMPILATION=1` tag. cmus doesn't know the former.

Upstream tells me that they're just following what iTunes is doing (but they'll add support for a `COMPILATION=1` tag in a future release), but in the meantime the following PR lets us accept `PARTOFACOMPILATION` tags as well.

Googling a bit reveals that some other programs might write this tag as well, although `COMPILATION=1` is probably more common. But since it looks like there's no real standard for this, I don't see many drawbacks of accepting this variant.