### PR TITLE
Add two new playlist commands: `pl-flush' & `pl-reload'.

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -252,7 +252,7 @@ int misc_init(void)
 	}
 	make_dir(cmus_config_dir);
 
-	cmus_playlist_dir = getenv("CMUS_PLAYLIST_DIR");
+	cmus_playlist_dir = get_non_empty_env("CMUS_PLAYLIST_DIR");
 	if (!cmus_playlist_dir)
 		cmus_playlist_dir = xstrjoin(cmus_config_dir, "/playlists");
 


### PR DESCRIPTION
This commit does the following:

  1. Adds two new commands:

     - `pl-flush` write all playlists to disk; this is what happens on exit today
     - `pl-reload` -- walk all files in the playlists directory & load them; existing playlists *not* backed by file will not be touched

  2. Housekeeping-- added gtags tags files to .gitignore & "*.lo" to `make clean`; documented the `CMUS_PLAYLISTS_DIR` environment variable