### PR TITLE
Change to get_non_empty_env for CMUS_PLAYLIST_DIR.

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -252,7 +252,7 @@ int misc_init(void)
 	}
 	make_dir(cmus_config_dir);
 
-	cmus_playlist_dir = getenv("CMUS_PLAYLIST_DIR");
+	cmus_playlist_dir = get_non_empty_env("CMUS_PLAYLIST_DIR");
 	if (!cmus_playlist_dir)
 		cmus_playlist_dir = xstrjoin(cmus_config_dir, "/playlists");
 


### PR DESCRIPTION
While doing some testing, I typed "export CMUS_PLAYLIST_DIR=; ./cmus". Not only did that break cmus, it produced a very unhelpful error message. Better to use get_non_empty_env.