### PR TITLE
Increasing print buffer to fix crashes on ultra wide screens

### DIFF
--- a/ui_curses.c
+++ b/ui_curses.c
@@ -118,7 +118,7 @@ static int error_count = 0;
 
 static char *server_address = NULL;
 
-static char print_buffer[512];
+static char print_buffer[1024];
 
 /* destination buffer for utf8_encode_to_buf and utf8_decode */
 static char conv_buffer[512];


### PR DESCRIPTION
On ultra wide screens cmus crashes. It seems to be due to buffer overflow when printing `print_buffer`. I bumped up the size of the buffer and it fixed the issue, at least on my screen. You can reproduce the issue on a regular screen by reducing the font size.

A more thorough solution would probably be to use bounds checks whenever printing the buffer. I tried that solution but it quickly got messy. My first attempts fixed the crashes but messed up the formatting of the output. A dynamic buffer might be easier to switch to but has that approach also has its own issues.