### PR TITLE
Make contrib/cmus-update*.py scripts use env python and fix pidgin with py3

### DIFF
--- a/contrib/cmus-updategaim.py
+++ b/contrib/cmus-updategaim.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import dbus

--- a/contrib/cmus-updatepidgin.py
+++ b/contrib/cmus-updatepidgin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import dbus
@@ -9,11 +9,7 @@ args = {}
 for n in range(1, len(sys.argv) - 1, 2):
 	args[sys.argv[n]] = sys.argv[n + 1]
 
-print args
-
-bus = dbus.SessionBus()
-
-obj = bus.get_object("im.pidgin.purple.PurpleService", "/im/pidgin/purple/PurpleObject")
+obj = dbus.SessionBus().get_object("im.pidgin.purple.PurpleService", "/im/pidgin/purple/PurpleObject")
 pidgin = dbus.Interface(obj, "im.pidgin.purple.PurpleInterface")
 
 current = pidgin.PurpleSavedstatusGetCurrent()
@@ -21,5 +17,4 @@ status_type = pidgin.PurpleSavedstatusGetType(current)
 saved = pidgin.PurpleSavedstatusNew("", status_type)
 pidgin.PurpleSavedstatusSetMessage(saved, "♪ %s - %s" % (args["artist"], args["title"]))
 pidgin.PurpleSavedstatusActivate(saved)
-
 


### PR DESCRIPTION
Changed shebang to use /usr/bin/env to get the python interpreter
updatepidgin: We simple remove the useless print without parenthesis.