### PR TITLE
Fixes various compiler warning

### DIFF
--- a/format_print.c
+++ b/format_print.c
@@ -185,7 +185,7 @@ static void print_str(const char *src)
 
 			if (ws_len < 0) {
 				int w, c = -ws_len;
-				uchar u;
+				uchar u = 0;
 
 				while (c > 0) {
 					u = u_get_char(src, &s);

--- a/input.c
+++ b/input.c
@@ -504,7 +504,7 @@ void ip_load_plugins(void)
 
 	ip_wrlock();
 	while ((d = (struct dirent *) readdir(dir)) != NULL) {
-		char filename[256];
+		char filename[512];
 		struct ip *ip;
 		void *so;
 		char *ext;

--- a/output.c
+++ b/output.c
@@ -91,7 +91,7 @@ void op_load_plugins(void)
 		return;
 	}
 	while ((d = (struct dirent *) readdir(dir)) != NULL) {
-		char filename[256];
+		char filename[512];
 		struct output_plugin *plug;
 		void *so, *symptr;
 		char *ext;

--- a/utils.h
+++ b/utils.h
@@ -331,7 +331,7 @@ static inline void clear_pipe(int pipe, size_t bytes)
 	char buf[128];
 	size_t bytes_to_read = min_u(sizeof(buf), bytes);
 	if (read(pipe, buf, bytes_to_read) < 0) {
-		d_print("read from pipe failed. errno = %d", errno);
+		d_print("read from pipe failed. errno = %d\n", errno);
 	}
 }
 

--- a/utils.h
+++ b/utils.h
@@ -322,7 +322,7 @@ static inline void notify_via_pipe(int pipe)
 {
 	char buf = 0;
 	if (write(pipe, &buf, 1) != 1) {
-		d_print("failed to write to pipe errno = %d\n", errno);
+		d_print("write to pipe failed. errno = %d\n", errno);
 	}
 }
 
@@ -331,7 +331,7 @@ static inline void clear_pipe(int pipe, size_t bytes)
 	char buf[128];
 	size_t bytes_to_read = min_u(sizeof(buf), bytes);
 	if (read(pipe, buf, bytes_to_read) < 0) {
-		d_print("failed to clear pipe. errno = %d", errno);
+		d_print("read from pipe failed. errno = %d", errno);
 	}
 }
 

--- a/utils.h
+++ b/utils.h
@@ -321,14 +321,18 @@ static inline void init_pipes(int *out, int *in)
 static inline void notify_via_pipe(int pipe)
 {
 	char buf = 0;
-	write(pipe, &buf, 1);
+	if (write(pipe, &buf, 1) != 1) {
+		d_print("failed to write to pipe errno = %d\n", errno);
+	}
 }
 
 static inline void clear_pipe(int pipe, size_t bytes)
 {
 	char buf[128];
 	size_t bytes_to_read = min_u(sizeof(buf), bytes);
-	read(pipe, buf, bytes_to_read);
+	if (read(pipe, buf, bytes_to_read) < 0) {
+		d_print("failed to clear pipe. errno = %d", errno);
+	}
 }
 
 static inline ssize_t strscpy(char *dst, const char *src, size_t size)


### PR DESCRIPTION
clean compile with gcc 8.2.0 and clang 7.0.1 (except for ffmpeg deprecations)