### PR TITLE
Fixes incorect bit rate declaration for 24bit flac

### DIFF
--- a/ip/flac.c
+++ b/ip/flac.c
@@ -217,8 +217,6 @@ static void metadata_cb(const Dec *dec, const FLAC__StreamMetadata *metadata, vo
 				break;
 			case 20:
 			case 24:
-				bits = 24;
-				break;
 			case 32:
 				bits = 32;
 				break;


### PR DESCRIPTION
flac inflates the bit rate to 32bit for 24bit files, but declares 24bit in
the sf structure.

fixes #644 