### PR TITLE
Fixed issue with `xstrndup`

### DIFF
--- a/xmalloc.c
+++ b/xmalloc.c
@@ -31,9 +31,14 @@ void malloc_fail(void)
 	exit(42);
 }
 
-#ifndef HAVE_STRNDUP
 char *xstrndup(const char *str, size_t n)
 {
+#ifdef HAVE_STRNDUP
+	char *s = strndup(str, n);
+	if (unlikely(s == NULL))
+		malloc_fail();
+	return s;
+#else
 	size_t len;
 	char *s;
 
@@ -43,5 +48,5 @@ char *xstrndup(const char *str, size_t n)
 	memcpy(s, str, len);
 	s[len] = 0;
 	return s;
-}
 #endif
+}

--- a/xmalloc.h
+++ b/xmalloc.h
@@ -73,17 +73,7 @@ static inline char * CMUS_MALLOC xstrdup(const char *str)
 #endif
 }
 
-#ifdef HAVE_STRNDUP
-static inline char * CMUS_MALLOC xstrndup(const char *str, size_t n)
-{
-	char *s = strndup(str, n);
-	if (unlikely(s == NULL))
-		malloc_fail();
-	return s;
-}
-#else
 char * CMUS_MALLOC xstrndup(const char *str, size_t n);
-#endif
 
 static inline void free_str_array(char **array)
 {


### PR DESCRIPTION
Previously, `ape` and a few other modules refused to link, citing a
missing `xstrndup`. This seemed to be due to some issue with
`HAVE_STRNDUP` checks not quite working. Here's a fix. The only issue is
that it may slow down `cmus` a bit since the inline definition (which
was in `xmalloc.h`) has been removed.