### PR TITLE
Ensures all data sent on dbus is in utf8 (#847)

### DIFF
--- a/mpris.c
+++ b/mpris.c
@@ -25,6 +25,7 @@
 #include "output.h"
 #include "track_info.h"
 #include "utils.h"
+#include "uchar.h"
 
 #define CK(v) \
 do { \
@@ -374,24 +375,44 @@ static int mpris_metadata(sd_bus *_bus, const char *_path,
 		dur *= 1000 * 1000;
 		CK(mpris_msg_append_sx_dict(reply, "mpris:length", dur));
 
-		if (ti->artist)
-			CK(mpris_msg_append_sas_dict(reply, "xesam:artist",
-						ti->artist));
-		if (ti->title)
-			CK(mpris_msg_append_ss_dict(reply, "xesam:title",
-						ti->title));
-		if (ti->album)
-			CK(mpris_msg_append_ss_dict(reply, "xesam:album",
-						ti->album));
-		if (ti->albumartist)
-			CK(mpris_msg_append_sas_dict(reply, "xesam:albumArtist",
-						ti->albumartist));
-		if (ti->genre)
-			CK(mpris_msg_append_sas_dict(reply, "xesam:genre",
-						ti->genre));
-		if (ti->comment)
-			CK(mpris_msg_append_sas_dict(reply, "xesam:comment",
-						ti->comment));
+		//The dbus connection closes if invalid data is sent.
+		//As a *temporary* fix, ensure all strings are encoded in utf8.
+		if (ti->artist) {
+			char corrected[u_str_width(ti->artist)];
+			u_to_utf8(corrected, ti->artist);
+			CK(mpris_msg_append_sas_dict(reply,
+					"xesam:artist", corrected));
+		}
+		if (ti->title) {
+			char corrected[u_str_width(ti->title)];
+			u_to_utf8(corrected, ti->title);
+			CK(mpris_msg_append_sas_dict(reply,
+					"xesam:title", corrected));
+		}
+		if (ti->album) {
+			char corrected[u_str_width(ti->album)];
+			u_to_utf8(corrected, ti->album);
+			CK(mpris_msg_append_sas_dict(reply,
+					"xesam:album", corrected));
+		}
+		if (ti->albumartist) {
+			char corrected[u_str_width(ti->albumartist)];
+			u_to_utf8(corrected, ti->albumartist);
+			CK(mpris_msg_append_sas_dict(reply,
+					"xesam:albumArtist", corrected));
+		}
+		if (ti->genre) {
+			char corrected[u_str_width(ti->genre)];
+			u_to_utf8(corrected, ti->genre);
+			CK(mpris_msg_append_sas_dict(reply,
+					"xesam:genre", corrected));
+		}
+		if (ti->comment) {
+			char corrected[u_str_width(ti->comment)];
+			u_to_utf8(corrected, ti->comment);
+			CK(mpris_msg_append_sas_dict(reply,
+					"xesam:comment", corrected));
+		}
 		if (ti->bpm != -1)
 			CK(mpris_msg_append_si_dict(reply, "xesam:audioBPM",
 						ti->bpm));

--- a/uchar.c
+++ b/uchar.c
@@ -520,6 +520,16 @@ int u_to_ascii(char *dst, const char *src, int len)
 	return i;
 }
 
+void u_to_utf8(char *dst, const char *src)
+{
+	int s = 0, d = 0;
+	uchar u;
+	do {
+		u = u_get_char(src, &s);
+		u_set_char(dst, &d, u);
+	} while (u!=0);
+}
+
 int u_skip_chars(const char *str, int *width)
 {
 	int w = *width;

--- a/uchar.h
+++ b/uchar.h
@@ -165,6 +165,17 @@ int u_copy_chars(char *dst, const char *src, int *width);
 int u_to_ascii(char *dst, const char *src, int len);
 
 /*
+ * @dst    destination buffer
+ * @src    null-terminated string
+ *
+ * Copies src into dst, changing all invalid utf8 bytes into <xx>,
+ * where xx is the value of the byte in hex.
+ *
+ * Expects dst to be large enough to fit src + the conversions.
+ */
+void u_to_utf8(char *dst, const char *src);
+
+/*
  * @str    null-terminated UTF-8 string, must be long enough
  * @width  how much to skip
  *


### PR DESCRIPTION
Partly addresses 847. All bytes that are invalid utf8 are converted
to <xx>, just like other areas in cmus. This is a temporary fix.