### PR TITLE
Add an option to disable autosaving

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -809,6 +809,10 @@ aaa_mode (all) [all, artist, album]
 	like there were only the files of the currently playing artist in the
 	library.
 
+autosave (true)
+	If enabled, cmus will automatically save its configuration to 
+	`$XDG_CONFIG_HOME/cmus/autosave` on exit.
+
 altformat_current [`Format String`]
 	Alternative format string for the line displaying currently playing
 	track.
@@ -1505,7 +1509,8 @@ cmus reads its configuration from 3 different places.
 
 `$XDG_CONFIG_HOME/cmus/autosave`
 	This is the first file cmus loads.  cmus saves its state on exit to
-	this file so you shouldn't edit it.
+	this file so you shouldn't edit it. You can disable autosaving by using
+	the autosave option.
 
 `/usr/share/cmus/rc`
 	If the autosave file didn't exist, this file is read instead.

--- a/options.c
+++ b/options.c
@@ -59,6 +59,7 @@ char *output_plugin = NULL;
 char *status_display_program = NULL;
 char *server_password;
 int auto_reshuffle = 1;
+int autosave = 1;
 int confirm_run = 1;
 int resume_cmus = 0;
 int show_hidden = 0;
@@ -486,6 +487,21 @@ static void set_auto_reshuffle(void *data, const char *buf)
 static void toggle_auto_reshuffle(void *data)
 {
 	auto_reshuffle ^= 1;
+}
+
+static void get_autosave(void *data, char *buf, size_t size)
+{
+	strscpy(buf, bool_names[autosave], size);
+}
+
+static void set_autosave(void *data, const char *buf)
+{
+	parse_bool(buf, &autosave);
+}
+
+static void toggle_autosave(void *data)
+{
+	autosave ^= 1;
 }
 
 static void get_follow(void *data, char *buf, size_t size)
@@ -1322,6 +1338,7 @@ static const struct {
 } simple_options[] = {
 	DT(aaa_mode)
 	DT(auto_reshuffle)
+    DT(autosave)
 	DN_FLAGS(device, OPT_PROGRAM_PATH)
 	DN(buffer_seconds)
 	DN(scroll_offset)
@@ -1538,6 +1555,9 @@ void options_load(void)
 
 void options_exit(void)
 {
+    if (!autosave) {
+        return;
+    }
 	struct cmus_opt *opt;
 	struct filter_entry *filt;
 	char filename_tmp[512];

--- a/options.c
+++ b/options.c
@@ -1338,7 +1338,7 @@ static const struct {
 } simple_options[] = {
 	DT(aaa_mode)
 	DT(auto_reshuffle)
-    DT(autosave)
+	DT(autosave)
 	DN_FLAGS(device, OPT_PROGRAM_PATH)
 	DN(buffer_seconds)
 	DN(scroll_offset)
@@ -1555,9 +1555,9 @@ void options_load(void)
 
 void options_exit(void)
 {
-    if (!autosave) {
-        return;
-    }
+	if (!autosave) {
+		return;
+	}
 	struct cmus_opt *opt;
 	struct filter_entry *filt;
 	char filename_tmp[512];

--- a/options.h
+++ b/options.h
@@ -127,6 +127,7 @@ extern int auto_expand_albums_search;
 extern int auto_expand_albums_selcur;
 extern int show_all_tracks;
 extern int auto_reshuffle;
+extern int autosave;
 extern int confirm_run;
 extern int resume_cmus;
 extern int show_hidden;


### PR DESCRIPTION
I (and probably some other people) prefer to edit the configuration file by hand. Especially when you try out some theming settings you usually don't want this to be immediately rewritten to your config file.

This PR adds an option to disable cmus autosave feature. This also solves the need for `bind -f` in your
cmus rc file (#742 ) as one could simply put `set autosave=false` in the there and create an empty autosave file to prevent reading of `/usr/share/cmus/rc`

There was once an issue opened for this feature (#732 ), but it was closed by OP for some reason.