### PR TITLE
Makes :quit only prompt if -i is given

### DIFF
--- a/command_mode.c
+++ b/command_mode.c
@@ -743,8 +743,7 @@ static void cmd_quit(char *arg)
 	int flag = parse_flags((const char **)&arg, "i");
 	enum ui_query_answer answer;
 	if (!worker_has_job_by_type(JOB_TYPE_ANY)) {
-		answer =  yes_no_query("Quit cmus? [y/N]");
-		if (flag != 'i' || answer != UI_QUERY_ANSWER_NO)
+		if (flag != 'i' || yes_no_query("Quit cmus? [y/N]") != UI_QUERY_ANSWER_NO)
 			cmus_running = 0;
 	} else {
 		answer = yes_no_query("Tracks are being added. Quit and truncate playlist(s)? [y/N]");


### PR DESCRIPTION
this is the original behaviour prior to fead80b

fixes #887