### PR TITLE
misc_init: remove variable user_name

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -41,7 +41,6 @@ const char *cmus_socket_path = NULL;
 const char *cmus_data_dir = NULL;
 const char *cmus_lib_dir = NULL;
 const char *home_dir = NULL;
-const char *user_name = NULL;
 
 char **get_words(const char *text)
 {
@@ -219,13 +218,6 @@ int misc_init(void)
 	home_dir = get_non_empty_env("HOME");
 	if (home_dir == NULL)
 		die("error: environment variable HOME not set\n");
-
-	user_name = get_non_empty_env("USER");
-	if (user_name == NULL) {
-		user_name = get_non_empty_env("USERNAME");
-		if (user_name == NULL)
-			die("error: neither USER or USERNAME environment variable set\n");
-	}
 
 	cmus_config_dir = get_non_empty_env("CMUS_HOME");
 	if (cmus_config_dir == NULL) {

--- a/misc.h
+++ b/misc.h
@@ -27,7 +27,6 @@ extern const char *cmus_socket_path;
 extern const char *cmus_data_dir;
 extern const char *cmus_lib_dir;
 extern const char *home_dir;
-extern const char *user_name;
 
 char **get_words(const char *text);
 int strptrcmp(const void *a, const void *b);


### PR DESCRIPTION
The variable wasn't used anywhere in cmus. Having it made cmus
unnecessarily required env var USER or USERNAME to work.