### PR TITLE
Fix :mark on playlist view so filter is used

### DIFF
--- a/pl.c
+++ b/pl.c
@@ -849,7 +849,7 @@ void pl_invert_marks(void)
 void pl_mark(char *arg)
 {
 	pl_tw_only("mark")
-		editable_invert_marks(&pl_visible->editable);
+		editable_mark(&pl_visible->editable, arg);
 }
 
 void pl_unmark(void)


### PR DESCRIPTION
The manpage says filter expressions can be used in views 2-4, and I don't see the utility in `:mark` inverting the selection in the playlist view.