### PR TITLE
Fix a crash when moving all tracks in a view

### DIFF
--- a/editable.c
+++ b/editable.c
@@ -247,8 +247,8 @@ static void move_sel(struct editable *e, struct list_head *after)
 	editable_track_to_iter(e, to_simple_track(after->next), &iter);
 
 	if (editable_owns_shared(e)) {
-		window_set_sel(e->shared->win, &iter);
 		window_changed(e->shared->win);
+		window_set_sel(e->shared->win, &iter);
 	}
 }
 


### PR DESCRIPTION
Marking all tracks in library/playlist/queue view and moving them using p/P would crash cmus. Fix this by updating window state *before* setting selected track after the move.

This fixes #599; note that moving all tracks is a no-op, but it’s still better not to crash.