### PR TITLE
Allow push to accept no arguments

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -518,6 +518,7 @@ push <text>
 		bind common w push filter artist=
 
 	Text can contain spaces and even trailing spaces will be honored.
+	Text can also be left blank.
 	This command can only be bound to a key but not used in the command
 	line directly.
 

--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -512,13 +512,13 @@ left-view
 right-view
 	Go to view "to the right" of current one, e.g. view 3 -> view 4.
 
-push <text>
+push [text]
 	Enter command mode with the command line pre-set to text. Example:
 
 		bind common w push filter artist=
 
 	Text can contain spaces and even trailing spaces will be honored.
-	Text can also be left blank.
+	If no text is given it defaults to a blank command line.
 	This command can only be bound to a key but not used in the command
 	line directly.
 

--- a/command_mode.c
+++ b/command_mode.c
@@ -1353,9 +1353,8 @@ static void cmd_view(char *arg)
 
 static void cmd_push(char *arg)
 {
-	if (arg) {
+	if (arg)
 		cmdline_set_text(arg);
-	}
 	enter_command_mode();
 }
 

--- a/command_mode.c
+++ b/command_mode.c
@@ -1353,7 +1353,9 @@ static void cmd_view(char *arg)
 
 static void cmd_push(char *arg)
 {
-	cmdline_set_text(arg);
+	if (arg) {
+		cmdline_set_text(arg);
+	}
 	enter_command_mode();
 }
 
@@ -2586,7 +2588,7 @@ struct command commands[] = {
 	{ "pl-export",             cmd_pl_export,        1, -1, NULL,                 0, 0          },
 	{ "pl-import",             cmd_pl_import,        0, -1, NULL,                 0, 0          },
 	{ "pl-rename",             cmd_pl_rename,        1, -1, NULL,                 0, 0          },
-	{ "push",                  cmd_push,             1, -1, expand_commands,      0, 0          },
+	{ "push",                  cmd_push,             0, -1, expand_commands,      0, 0          },
 	{ "pwd",                   cmd_pwd,              0, 0,  NULL,                 0, 0          },
 	{ "raise-vte",             cmd_raise_vte,        0, 0,  NULL,                 0, 0          },
 	{ "rand",                  cmd_rand,             0, 0,  NULL,                 0, 0          },


### PR DESCRIPTION
Implements #930

Allows the push command to be used with no arguments. This results in an empty command line.