### PR TITLE
Fix segfault on ppc64 caused by narrowing cast

### DIFF
--- a/format_print.c
+++ b/format_print.c
@@ -216,7 +216,8 @@ static void print_str(const char *src)
 
 		}
 	} else {
-		int s = 0, d = 0;
+		int s = 0;
+		size_t d = 0;
 		uchar u;
 
 		while (1) {
@@ -471,7 +472,7 @@ static void format_parse(int str_width, const char *format, const struct format_
 		u = u_get_char(format, &s);
 		if (u != '%') {
 			gbuf_grow(str, 4);
-			u_set_char(str->buffer, (int *)&str->len, u);
+			u_set_char(str->buffer, &str->len, u);
 			(*len) += u_char_width(u);
 			continue;
 		}
@@ -594,7 +595,7 @@ static void format_write(char *buf, int str_width)
 		strcpy(buf + pos + ws_len, r_str.buffer);
 	} else {
 		int l_space = str_width - str_len.rlen;
-		int pos = 0;
+		size_t pos = 0;
 		int idx = 0;
 
 		if (l_space > 0)

--- a/id3.c
+++ b/id3.c
@@ -287,10 +287,10 @@ static int utf16_is_special(uchar uch)
 	return utf16_is_hsurrogate(uch) || utf16_is_lsurrogate(uch) || utf16_is_bom(uch);
 }
 
-static char *utf16_to_utf8(const unsigned char *buf, int buf_size)
+static char *utf16_to_utf8(const unsigned char *buf, size_t buf_size)
 {
 	char *out;
-	int i, idx;
+	size_t i, idx;
 	int little_endian = 0;
 
 	if (buf_size < 2)

--- a/uchar.c
+++ b/uchar.c
@@ -428,7 +428,7 @@ void u_set_char_raw(char *str, int *idx, uchar uch)
  * Printing functions, these lose information
  */
 
-void u_set_char(char *str, int *idx, uchar uch)
+void u_set_char(char *str, size_t *idx, uchar uch)
 {
 	int i = *idx;
 
@@ -476,10 +476,11 @@ invalid:
 	}
 }
 
-int u_copy_chars(char *dst, const char *src, int *width)
+size_t u_copy_chars(char *dst, const char *src, int *width)
 {
 	int w = *width;
-	int si = 0, di = 0;
+	int si = 0;
+	size_t di = 0;
 	int cw;
 	uchar u;
 
@@ -522,7 +523,8 @@ int u_to_ascii(char *dst, const char *src, int len)
 
 void u_to_utf8(char *dst, const char *src)
 {
-	int s = 0, d = 0;
+	int s = 0;
+	size_t d = 0;
 	uchar u;
 	do {
 		u = u_get_char(src, &s);

--- a/uchar.h
+++ b/uchar.h
@@ -137,7 +137,7 @@ uchar u_get_char(const char *str, int *idx);
  * @uch  unicode character
  */
 void u_set_char_raw(char *str, int *idx, uchar uch);
-void u_set_char(char *str, int *idx, uchar uch);
+void u_set_char(char *str, size_t *idx, uchar uch);
 
 /*
  * @dst    destination buffer
@@ -150,7 +150,7 @@ void u_set_char(char *str, int *idx, uchar uch);
  *
  * Returns number of _bytes_ copied.
  */
-int u_copy_chars(char *dst, const char *src, int *width);
+size_t u_copy_chars(char *dst, const char *src, int *width);
 
 /*
  * @dst    destination buffer

--- a/ui_curses.c
+++ b/ui_curses.c
@@ -467,7 +467,8 @@ static void dump_print_buffer(int row, int col)
  */
 static int format_str(char *buf, const char *str, int width)
 {
-	int s = 0, d = 0, ellipsis_pos = 0, cut_double_width = 0;
+	int s = 0, ellipsis_pos = 0, cut_double_width = 0;
+	size_t d = 0;
 
 	while (1) {
 		uchar u;
@@ -1237,7 +1238,8 @@ static void dump_buffer(const char *buffer)
 static void do_update_commandline(void)
 {
 	char *str;
-	int w, idx;
+	int w;
+	size_t idx;
 	char ch;
 
 	move(LINES - 1, 0);


### PR DESCRIPTION
The narrowing cast happens with the second argument in the call to
`u_set_char()` in `format_parse()` in format_print.c. The argument is
`str->len`.

Before this commit, `&str->len` was cast to `(int *)`, despite `str` being
a `struct gbuf` whose `len` member has type `size_t`.

This does not cause an issue on 64-bit little-endian systems because a
cast to `int *`, though narrowing, points to the bottom four bytes of
`str->len`, and so the incrementing of the local copy of the `idx`
parameter in `u_set_char()` and then the assignment back to `*idx` doesn't
have any undesired behavior.

64-bit little-endian
```
|0|1|2|3|4|5|6|7| (str->len, numbers indicate byte significance)
 ^
 |
 |_(size_t *)

|0|1|2|3|
 ^
 |_(int *)
```
An increment here on 64-bit little-endian increases the value held in
byte 0, which is the expected result, so narrowing has no detrimental
effect.

However the narrowing cast causes a bug on big-endian 64-bit
systems (such as ppc64) because a cast to `int *` points to the top
four bytes of `str->len`.

64-bit big-endian
```
|7|6|5|4|3|2|1|0| (str->len)
 ^
 |
 |_(size_t *)

|7|6|5|4|
 ^
 |_(int *)
```
Besides `u_set_char()` being passed the top 4 bytes when the bottom 4
bytes are desired, an increment of the local copy of `idx` in
`u_set_char()` and the assignment back to `*idx` increases the value held
in byte 4, when byte 0 should be incremented. So the assignment back
to `*idx` increases the value of `str->len` by 2^32, and thus the next
time `str->len` is used for array access a segfault occurs.

This commit fixes the bug by changing the `idx` parameter of
`u_set_char()` from type `int *` to type `size_t *`, and removing the
cast to `int *` in `format_parse()`.

This commit also updates all functions that use `u_set_char()` to pass
a `size_t *` argument in order to eliminate any warnings about
incompatible pointer types.