### PR TITLE
Fix type of MPRIS2 fields title and album

### DIFF
--- a/mpris.c
+++ b/mpris.c
@@ -386,13 +386,13 @@ static int mpris_metadata(sd_bus *_bus, const char *_path,
 		if (ti->title) {
 			char corrected[u_str_width(ti->title)];
 			u_to_utf8(corrected, ti->title);
-			CK(mpris_msg_append_sas_dict(reply,
+			CK(mpris_msg_append_ss_dict(reply,
 					"xesam:title", corrected));
 		}
 		if (ti->album) {
 			char corrected[u_str_width(ti->album)];
 			u_to_utf8(corrected, ti->album);
-			CK(mpris_msg_append_sas_dict(reply,
+			CK(mpris_msg_append_ss_dict(reply,
 					"xesam:album", corrected));
 		}
 		if (ti->albumartist) {


### PR DESCRIPTION
The `title` and `album` mpris2 fields were sent as list of strings,
which caused issues with the GNOME integrated notification system.

The mpris2 specification states that these two fields should be strings,
not lists of strings.