### PR TITLE
Add support for 'DISCNUMBER' REM-field in CUE-sheets

### DIFF
--- a/cue.c
+++ b/cue.c
@@ -192,6 +192,7 @@ CUE_PARSE_STR(genre)
 CUE_PARSE_STR(date)
 CUE_PARSE_STR(comment)
 CUE_PARSE_STR(compilation);
+CUE_PARSE_STR(discnumber);
 
 static void cue_parse_file(struct cue_parser *p)
 {
@@ -288,6 +289,7 @@ static void cue_parse_rem(struct cue_parser *p)
 		{ "GENRE",       cue_parse_genre       },
 		{ "COMMENT",     cue_parse_comment     },
 		{ "COMPILATION", cue_parse_compilation },
+		{ "DISCNUMBER",  cue_parse_discnumber  },
 		{ 0 },
 	};
 

--- a/cue.h
+++ b/cue.h
@@ -28,6 +28,7 @@ struct cue_meta {
 	char *date;
 	char *comment;
 	char *compilation;
+	char *discnumber;
 };
 
 struct cue_track {

--- a/ip/cue.c
+++ b/ip/cue.c
@@ -255,6 +255,8 @@ static int cue_read_comments(struct input_plugin_data *ip_data, struct keyval **
 		comments_add_const(&c, "date", cd->meta.date);
 	if (cd->meta.compilation)
 		comments_add_const(&c, "compilation", cd->meta.compilation);
+	if (cd->meta.discnumber)
+		comments_add_const(&c, "discnumber", cd->meta.discnumber);
 
 	/*
 	 * TODO:


### PR DESCRIPTION
Tools like Exact Audio Copy use the "REM DISCNUMBER" comment as a convention to store the disc-number of a multi-disc album within the cue-sheet.

Other players that implement this convention are for example Foobar2000 or Clementine.

Currently in cmus track sorting wrong for such albums, alternating tracks with the same numbers from disc 1 and disc 2 etc.