### PR TITLE
cue: play pregaps of songs by adding them at the end of the previous song

### DIFF
--- a/cue.c
+++ b/cue.c
@@ -412,7 +412,7 @@ static struct cue_sheet *cue_parser_to_sheet(struct cue_parser *p)
 		if (idx > 0) {
 			int32_t postgap = prev->postgap != -1 ? prev->postgap : 0;
 			s->tracks[idx - 1].length =
-				(t->index0 - prev->index1 - postgap) / 75.0;
+				(t->index1 - prev->index1 - postgap) / 75.0;
 		}
 
 		cue_meta_move(&s->tracks[idx].meta, &t->meta);


### PR DESCRIPTION
I noticed, that cmus doesn't play pregaps of tracks from cue sheets.

Here's a short explanation of this change:

The cuesheet defines this:
```
Index  1         0        1
       | Track 1 |     Track 2      |
       |         | Pregap |         |

before | Track 1 | *skip* | Track 2 |
after  | Track 1          | Track 2 |
```
Cmus calculated the lenth of track 1 by substracting index 0 from track 2 with index 1 from track 1.  However the start of track 2 is always index 1 of track 2.  So by adding the pregap to the lenght of track 1 we make sure that the user hears the transition before track 2 starts.

Here's a short example which is the transition from track 2 to track 3 on Beastie Boys' "Hello Nasty":

[pregap.tar.gz](https://github.com/cmus/cmus/files/5500491/pregap.tar.gz)

It contains 10 seconds of the end of the track, then there's about 40 seconds of pregap and 10 seconds of the next track.

Before cmus just skipped the 40 seconds of pregap and jumped to the beginning of the next track.  With this patch we can enjoy the 40 seconds transition.
