### PR TITLE
Add -f, --file options to cmus-remote manual

### DIFF
--- a/Doc/cmus-remote.txt
+++ b/Doc/cmus-remote.txt
@@ -65,6 +65,9 @@ If *-C* is given, all command line arguments are treated as raw commands.
 -k, --seek SEEK
 	Seek. See *seek* command in *cmus*(1).
 
+-f, --file FILE
+	Play from file.
+
 -Q
 	Get player status information.  Same as *-C status*.  Note that
 	*status* is a special command only available to cmus-remote.


### PR DESCRIPTION
This fixes #979.

While experimenting with this, I noticed that my zshell's autocomplete doesn't mention -f either, nor does it mention other important options like even -Q. I imagine that it has to do with this file:
https://github.com/eshrh/cmus/blob/remote-f-doc/contrib/_cmus
I'll look into this further, and maybe open another issue.