### PR TITLE
properly calculate size of print string from u_to_utf8

### DIFF
--- a/mpris.c
+++ b/mpris.c
@@ -378,37 +378,37 @@ static int mpris_metadata(sd_bus *_bus, const char *_path,
 		//The dbus connection closes if invalid data is sent.
 		//As a *temporary* fix, ensure all strings are encoded in utf8.
 		if (ti->artist) {
-			char corrected[u_str_width(ti->artist)];
+			char corrected[u_str_print_size(ti->artist)];
 			u_to_utf8(corrected, ti->artist);
 			CK(mpris_msg_append_sas_dict(reply,
 					"xesam:artist", corrected));
 		}
 		if (ti->title) {
-			char corrected[u_str_width(ti->title)];
+			char corrected[u_str_print_size(ti->title)];
 			u_to_utf8(corrected, ti->title);
 			CK(mpris_msg_append_sas_dict(reply,
 					"xesam:title", corrected));
 		}
 		if (ti->album) {
-			char corrected[u_str_width(ti->album)];
+			char corrected[u_str_print_size(ti->album)];
 			u_to_utf8(corrected, ti->album);
 			CK(mpris_msg_append_sas_dict(reply,
 					"xesam:album", corrected));
 		}
 		if (ti->albumartist) {
-			char corrected[u_str_width(ti->albumartist)];
+			char corrected[u_str_print_size(ti->albumartist)];
 			u_to_utf8(corrected, ti->albumartist);
 			CK(mpris_msg_append_sas_dict(reply,
 					"xesam:albumArtist", corrected));
 		}
 		if (ti->genre) {
-			char corrected[u_str_width(ti->genre)];
+			char corrected[u_str_print_size(ti->genre)];
 			u_to_utf8(corrected, ti->genre);
 			CK(mpris_msg_append_sas_dict(reply,
 					"xesam:genre", corrected));
 		}
 		if (ti->comment) {
-			char corrected[u_str_width(ti->comment)];
+			char corrected[u_str_print_size(ti->comment)];
 			u_to_utf8(corrected, ti->comment);
 			CK(mpris_msg_append_sas_dict(reply,
 					"xesam:comment", corrected));

--- a/uchar.c
+++ b/uchar.c
@@ -532,6 +532,28 @@ void u_to_utf8(char *dst, const char *src)
 	} while (u!=0);
 }
 
+int u_print_size(uchar uch)
+{
+	int s = u_char_size(uch);
+	/* control characters and invalid unicode set as <XX> */
+	if (uch < 0x0000001fU && uch != 0){
+		return 4;
+	}
+	return s;
+}
+
+int u_str_print_size(const char *str)
+{
+	int l = 0;
+	int idx = 0;
+	uchar u;
+	do {
+		u = u_get_char(str, &idx);
+		l += u_print_size(u);
+	} while (u!=0);
+	return l;
+}
+
 int u_skip_chars(const char *str, int *width)
 {
 	int w = *width;

--- a/uchar.h
+++ b/uchar.h
@@ -105,6 +105,20 @@ size_t u_strlen_safe(const char *str);
 int u_str_width(const char *str);
 
 /*
+ * @uch  unicode character
+ *
+ * Retuns size of @uch if it were printed.
+ */
+int u_print_size(uchar uch);
+
+/*
+ * @str  null-terminated UTF-8 string
+ *
+ * Retuns size of @str if it were printed.
+ */
+int u_str_print_size(const char *str);
+
+/*
  * @str  null-terminated UTF-8 string
  * @len  number of characters to measure
  *


### PR DESCRIPTION
fix #885 
description of bug:
https://github.com/cmus/cmus/issues/885#issuecomment-477761446
to correctly calculate the space required for u_to_utf8, account for control characters and invalid utf8 being printed as `<XX>` by u_set_char.
I called my new functions "print size" because u_set_char and u_to_utf8 are under a comment that says "Printing functions, these lose information"