### PR TITLE
Support R128_TRACK_GAIN / R128_ALBUM_GAIN tags

### DIFF
--- a/comment.c
+++ b/comment.c
@@ -125,6 +125,18 @@ int comments_get_int(const struct keyval *comments, const char *key)
 	return ival;
 }
 
+int comments_get_signed_int(const struct keyval *comments, const char *key, long int *ival)
+{
+	const char *val;
+
+	val = keyvals_get_val(comments, key);
+	if (val == NULL)
+		return -1;
+	while (*val && !(*val == '+' || *val == '-' || (*val >= '0' && *val <= '9')))
+		val++;
+	return str_to_int(val, ival);
+}
+
 double comments_get_double(const struct keyval *comments, const char *key)
 {
 	const char *val;
@@ -187,6 +199,8 @@ static const char *interesting[] = {
 	"date", "compilation", "partofacompilation", "albumartist", "artistsort", "albumartistsort",
 	"albumsort",
 	"originaldate",
+	"r128_track_gain",
+	"r128_album_gain",
 	"replaygain_track_gain",
 	"replaygain_track_peak",
 	"replaygain_album_gain",

--- a/comment.h
+++ b/comment.h
@@ -28,6 +28,7 @@ const char *comments_get_albumartist(const struct keyval *comments);
 const char *comments_get_artistsort(const struct keyval *comments); /* can return NULL */
 
 int comments_get_int(const struct keyval *comments, const char *key);
+int comments_get_signed_int(const struct keyval *comments, const char *key, long int *ival);
 double comments_get_double(const struct keyval *comments, const char *key);
 int comments_get_date(const struct keyval *comments, const char *key);
 

--- a/track_info.c
+++ b/track_info.c
@@ -63,6 +63,9 @@ struct track_info *track_info_new(const char *filename)
 }
 
 void track_info_set_comments(struct track_info *ti, struct keyval *comments) {
+	long int r128_track_gain;
+	long int r128_album_gain;
+
 	ti->comments = comments;
 	ti->artist = keyvals_get_val(comments, "artist");
 	ti->album = keyvals_get_val(comments, "album");
@@ -98,6 +101,14 @@ void track_info_set_comments(struct track_info *ti, struct keyval *comments) {
 	ti->rg_track_peak = comments_get_double(comments, "replaygain_track_peak");
 	ti->rg_album_gain = comments_get_double(comments, "replaygain_album_gain");
 	ti->rg_album_peak = comments_get_double(comments, "replaygain_album_peak");
+
+	if (comments_get_signed_int(comments, "r128_track_gain", &r128_track_gain) != -1) {
+		ti->rg_track_gain = (r128_track_gain / 256.0) + 5;
+	}
+
+	if (comments_get_signed_int(comments, "r128_album_gain", &r128_album_gain) != -1) {
+		ti->rg_album_gain = (r128_album_gain / 256.0) + 5;
+	}
 
 	ti->collkey_artist = u_strcasecoll_key0(ti->artist);
 	ti->collkey_album = u_strcasecoll_key0(ti->album);


### PR DESCRIPTION
These tags target -23 LUFS while REPLAYGAIN targets -18 LUFS, thus we
need to add a bias of 5 to get a loudness that's consistent with
REPLAYGAIN'd tracks.

Closes #785