### PR TITLE
Stop after queue (resolves #696)

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -1134,6 +1134,9 @@ status_display_program () [command]
 	background or panel for example.  See
 	`/usr/share/doc/cmus/examples/cmus-status-display`.
 
+stop_after_queue (false)
+	Stop playback when end of play queue is reached.
+
 time_show_leading_zero (true)
 	Pad durations of less than 10 minutes with a leading 0
 

--- a/cmus.c
+++ b/cmus.c
@@ -55,6 +55,7 @@ static char **playable_exts;
 static const char * const playlist_exts[] = { "m3u", "pl", "pls", NULL };
 
 int cmus_next_track_request_fd;
+static bool play_queue_active = false;
 static int cmus_next_track_request_fd_priv;
 static pthread_mutex_t cmus_next_file_mutex = CMUS_MUTEX_INITIALIZER;
 static pthread_cond_t cmus_next_file_cond = CMUS_COND_INITIALIZER;
@@ -397,8 +398,13 @@ int cmus_playlist_for_each(const char *buf, int size, int reverse,
 static struct track_info *cmus_get_next_from_main_thread(void)
 {
 	struct track_info *ti = play_queue_remove();
-	if (!ti)
-		ti = play_library ? lib_goto_next() : pl_goto_next();
+	if (ti) {
+		play_queue_active = true;
+	} else {
+		if (!play_queue_active || !stop_after_queue)
+			ti = play_library ? lib_goto_next() : pl_goto_next();
+		play_queue_active = false;
+	}
 	return ti;
 }
 

--- a/options.c
+++ b/options.c
@@ -84,6 +84,7 @@ int mouse = 0;
 int mpris = 1;
 int time_show_leading_zero = 1;
 int start_view = TREE_VIEW;
+int stop_after_queue = 0;
 
 int colors[NR_COLORS] = {
 	-1,
@@ -1147,6 +1148,21 @@ static void set_lib_add_filter(void *data, const char *buf)
 	lib_set_add_filter(expr);
 }
 
+static void get_stop_after_queue(void *data, char *buf, size_t size)
+{
+	strscpy(buf, bool_names[stop_after_queue], size);
+}
+
+static void set_stop_after_queue(void *data, const char *buf)
+{
+	parse_bool(buf, &stop_after_queue);
+}
+
+static void toggle_stop_after_queue(void *data)
+{
+	stop_after_queue ^= 1;
+}
+
 /* }}} */
 
 /* special callbacks (id set) {{{ */
@@ -1384,6 +1400,7 @@ static const struct {
 	DT(time_show_leading_zero)
 	DN(lib_add_filter)
 	DN(start_view)
+	DT(stop_after_queue)
 	{ NULL, NULL, NULL, NULL, 0 }
 };
 

--- a/options.h
+++ b/options.h
@@ -148,6 +148,7 @@ extern int mouse;
 extern int mpris;
 extern int time_show_leading_zero;
 extern int start_view;
+extern int stop_after_queue;
 
 extern const char * const aaa_mode_names[];
 extern const char * const view_names[NR_VIEWS + 1];


### PR DESCRIPTION
closes #696 

Adds a new option to prevent playback continuing onto the whole library
once the end of the queue is reached. Defaults to false. Enable with
`:set stop_after_queue=false`