### PR TITLE
Shuffle first track (#893)

### DIFF
--- a/pl.c
+++ b/pl.c
@@ -655,8 +655,8 @@ struct track_info *pl_play_selected_row(void)
 			struct simple_track *track = &st->simple_track;
 			rv = pl_play_track(pl_visible, track);
 		}
-		window_goto_top(pl_editable_shared.win);
 	}
+	pl_select_playing_track();
 
 	if (!rv)
 		rv = pl_play_selected_track();


### PR DESCRIPTION
fixes #893 

When starting playback of a playlist and shuffle is on, the first track
in the playlist was started rather than the first in the shuffled list.
This would result in playback stopping before reaching all files in the
list.