### PR TITLE
Make mouse behavior on playlist window consistent with library

### DIFF
--- a/keys.c
+++ b/keys.c
@@ -720,7 +720,7 @@ static const struct key *normal_mode_mouse_handle(MEVENT* event)
 			win = pl_list_win;
 		else
 		    return NULL;
-		is_sel = (pl_cursor_win() != win);
+		is_sel = (pl_cursor_win() == win);
 	} else {
 		win = current_win();
 		is_sel = 1;

--- a/keys.c
+++ b/keys.c
@@ -29,6 +29,7 @@
 #include "options.h"
 #include "editable.h"
 #include "lib.h"
+#include "pl.h"
 
 const char * const key_context_names[NR_CTXS + 1] = {
 	"browser",
@@ -712,6 +713,14 @@ static const struct key *normal_mode_mouse_handle(MEVENT* event)
 		else
 			return NULL;
 		is_sel = (lib_cur_win == win);
+	} else if (cur_view == PLAYLIST_VIEW) {
+		if (event->x >= track_win_x)
+			win = pl_editable_shared.win;
+		else if (event->x < track_win_x)
+			win = pl_list_win;
+		else
+		    return NULL;
+		is_sel = (pl_cursor_win() != win);
 	} else {
 		win = current_win();
 		is_sel = 1;
@@ -724,11 +733,15 @@ static const struct key *normal_mode_mouse_handle(MEVENT* event)
 		need_sel = 0;
 		if (cur_view == TREE_VIEW && lib_cur_win != win)
 			tree_toggle_active_window();
+		if (cur_view == PLAYLIST_VIEW && pl_cursor_win() != win)
+			pl_win_next();
 	} else {
 		if (event->y < 1 || event->y > window_get_nr_rows(win))
 			return NULL;
 		if (cur_view == TREE_VIEW && lib_cur_win != win)
 			tree_toggle_active_window();
+		if (cur_view == PLAYLIST_VIEW && pl_cursor_win() != win)
+			pl_win_next();
 		if (!window_get_top(win, &it) || !window_get_sel(win, &sel))
 			return NULL;
 		while (i-- > 0)

--- a/pl.c
+++ b/pl.c
@@ -46,7 +46,7 @@ struct playlist {
 
 static struct playlist *pl_visible; /* never NULL */
 static struct playlist *pl_marked; /* never NULL */
-static struct window *pl_list_win;
+struct window *pl_list_win;
 
 /* pl_playing_track shares its track_info reference with the playlist it's in.
  * pl_playing_track and pl_playing might be null but pl_playing_track != NULL
@@ -56,7 +56,7 @@ static struct simple_track *pl_playing_track;
 static struct playlist *pl_playing;
 
 static int pl_cursor_in_track_window;
-static struct editable_shared pl_editable_shared;
+struct editable_shared pl_editable_shared;
 static LIST_HEAD(pl_head); /* never empty */
 
 static struct searchable *pl_searchable;

--- a/pl.h
+++ b/pl.h
@@ -32,6 +32,9 @@ struct pl_list_info {
 	unsigned current : 1;
 };
 
+extern struct window *pl_list_win;
+extern struct editable_shared pl_editable_shared;
+
 void pl_init(void);
 void pl_exit(void);
 void pl_save(void);


### PR DESCRIPTION
Previously, scrolling or clicking within an inactive playlist pane would not select it; the event would just act upon the currently selected pane. This behavior was not consistent with the library view.

fixes #1010