### PR TITLE
Fixes truncation warnings by replacing %s with %.s

### DIFF
--- a/ui_curses.c
+++ b/ui_curses.c
@@ -924,7 +924,7 @@ static void print_filter(struct window *win, int row, struct iter *iter)
 		e_filter = conv_buffer;
 	}
 
-	snprintf(buf, sizeof(buf), "%c%c%c%-15s  %s", ch1, ch2, ch3, e->name, e_filter);
+	snprintf(buf, sizeof(buf), "%c%c%c%-15s  %.235s", ch1, ch2, ch3, e->name, e_filter);
 	pos = format_str(print_buffer, buf, COLS - 1);
 	print_buffer[pos++] = ' ';
 	print_buffer[pos] = 0;
@@ -1105,8 +1105,7 @@ static void update_editable_window(struct editable *e, const char *title, const 
 			utf8_encode_to_buf(filename);
 			filename = conv_buffer;
 		}
-		snprintf(buf, sizeof(buf), "%s %s - %d tracks", title,
-				pretty(filename), e->nr_tracks);
+		snprintf(buf, sizeof(buf), "%s %.256s - %d tracks", title, pretty(filename), e->nr_tracks);
 	} else {
 		snprintf(buf, sizeof(buf), "%s - %d tracks", title, e->nr_tracks);
 	}
@@ -1147,7 +1146,7 @@ static void update_browser_window(void)
 		utf8_encode_to_buf(browser_dir);
 		dirname = conv_buffer;
 	}
-	snprintf(title, sizeof(title), "Browser - %s", dirname);
+	snprintf(title, sizeof(title), "Browser - %.501s", dirname);
 	update_window(browser_win, 0, 0, COLS, title, print_browser);
 }
 


### PR DESCRIPTION
Fixes gcc warnings about format trunctations