### PR TITLE
Fix playlist track selection

### DIFF
--- a/pl.c
+++ b/pl.c
@@ -647,6 +647,9 @@ struct track_info *pl_play_selected_row(void)
 
 	int was_in_track_window = pl_cursor_in_track_window;
 
+	struct playlist *prev_pl = pl_playing;
+	struct simple_track *prev_track = pl_playing_track;
+
 	struct track_info *rv = NULL;
 
 	if (!pl_cursor_in_track_window) {
@@ -659,9 +662,6 @@ struct track_info *pl_play_selected_row(void)
 
 	if (!rv)
 		rv = pl_play_selected_track();
-
-	struct playlist *prev_pl = pl_playing;
-	struct simple_track *prev_track = pl_playing_track;
 
 	if (shuffle && rv && (pl_playing == prev_pl) && prev_track) {
 		struct shuffle_track *prev_st = simple_track_to_shuffle_track(prev_track);

--- a/pl.c
+++ b/pl.c
@@ -322,7 +322,7 @@ static struct simple_track *pl_get_first_track(struct playlist *pl)
 	}
 }
 
-static struct track_info *pl_play_track(struct playlist *pl, struct simple_track *t)
+static struct track_info *pl_play_track(struct playlist *pl, struct simple_track *t, bool force_follow)
 {
 	/* t is a track in pl */
 
@@ -333,7 +333,7 @@ static struct track_info *pl_play_track(struct playlist *pl, struct simple_track
 	pl_playing = pl;
 	pl_editable_shared.win->changed = 1;
 
-	if (follow)
+	if (force_follow || follow)
 		pl_select_playing_track();
 
 	/* reference owned by the caller */
@@ -347,7 +347,7 @@ static struct track_info *pl_play_selected_track(void)
 	if (pl_empty(pl_visible))
 		return NULL;
 
-	return pl_play_track(pl_visible, pl_get_selected_track());
+	return pl_play_track(pl_visible, pl_get_selected_track(), false);
 }
 
 static struct track_info *pl_play_first_in_pl_playing(void)
@@ -360,7 +360,7 @@ static struct track_info *pl_play_first_in_pl_playing(void)
 		return NULL;
 	}
 
-	return pl_play_track(pl_playing, pl_get_first_track(pl_playing));
+	return pl_play_track(pl_playing, pl_get_first_track(pl_playing), false);
 }
 
 static struct simple_track *pl_get_next(struct playlist *pl, struct simple_track *cur)
@@ -490,7 +490,7 @@ static struct track_info *pl_goto_generic(pl_shuffled_move shuffled,
 		track = normal(pl_playing, pl_playing_track);
 
 	if (track)
-		return pl_play_track(pl_playing, track);
+		return pl_play_track(pl_playing, track, false);
 	return NULL;
 }
 
@@ -653,10 +653,9 @@ struct track_info *pl_play_selected_row(void)
 		if (shuffle && !pl_empty(pl_visible)) {
 			struct shuffle_track *st = shuffle_list_get_next(&pl_visible->shuffle_root, NULL, pl_dummy_filter);
 			struct simple_track *track = &st->simple_track;
-			rv = pl_play_track(pl_visible, track);
+			rv = pl_play_track(pl_visible, track, true);
 		}
 	}
-	pl_select_playing_track();
 
 	if (!rv)
 		rv = pl_play_selected_track();


### PR DESCRIPTION
* Only select the playing track when selecting a playlist with shuffle enabled. This fixes the regression in #1008 which caused the currently playing track to be selected when activating any row in the playlist view.
* Remove (harmless) duplicate pl_select_playing_track call.
* Make the relationship between the follow option and the code which selects the shuffled track more explicit.

See https://github.com/cmus/cmus/pull/1008/commits/8fdd16a5013eb56922f531ad0608e78d4f073be3#r560385478. Fixes #1046.