### PR TITLE
Allow test of string length in format conditionals

### DIFF
--- a/format_print.c
+++ b/format_print.c
@@ -277,6 +277,8 @@ static int int_val(const char *key, const struct format_option *fopts, char *buf
 	if (fo && !fo->empty) {
 		if (fo->type == FO_INT)
 			val = fo->fo_int;
+		else if (fo->type == FO_STR)
+			val = strlen(fo->fo_str);
 	}
 	return val;
 }


### PR DESCRIPTION
This gives flexibility that might be desirable for "format_current",
e.g. to limit the artist and album to at most 20 characters each:
`format_current= %{?a>20?%-18a..?%a} / %{?l>20?%-18l..?%l} / %n - %t%= %y`

I think this is more useful than implementing a "maximum width" formatter (`%.20l`) because it lets us add "..." when the string is clipped. The example use case is the only one I can think of. There's probably some doc update needed, but I wanted to see if this would even be considered before bothering with that.

Closes #1004.