### PR TITLE
Fix segfault when reading mp4 files

### DIFF
--- a/configure
+++ b/configure
@@ -415,21 +415,7 @@ check_mp4()
 	then
 		USE_MPEG4IP=0
 	else
-		# techsmith cripples the mp4v2 api so badly that we can't even check for
-		# headers, as the C++ causes any call to gcc to just fail. If the header
-		# check fails but mp4v2 is still linkable, assume that we the system has
-		# the techsmith fork and mark it as such.
-		msg_checking "for techsmith mp4v2 fork"
-
-		if try_link -lmp4v2
-		then
-			msg_result yes
-			USE_MPEG4IP=0
-			IS_TS_MP4V2=1
-		else
-			msg_result no
-			return $?
-		fi
+		return $?
 	fi
 
 	check_header neaacdec.h &&

--- a/configure
+++ b/configure
@@ -415,7 +415,20 @@ check_mp4()
 	then
 		USE_MPEG4IP=0
 	else
-		return $?
+		# techsmith cripples the mp4v2 api so badly that we can't even check for
+		# headers, as the C++ causes any call to gcc to just fail. If the header
+		# check fails but mp4v2 is still linkable, assume that we the system has
+		# the techsmith fork and mark it as such.
+		msg_checking "for techsmith mp4v2 fork"
+
+		if try_link -lmp4v2
+		then
+			msg_result yes
+			return $?
+		else
+			msg_result no
+			return $?
+		fi
 	fi
 
 	check_header neaacdec.h &&

--- a/configure
+++ b/configure
@@ -431,6 +431,8 @@ check_mp4()
 		fi
 	fi
 
+	echo "GJUIKLP;SWEANFUIJ BJAESGFBUIYO"
+
 	check_header neaacdec.h &&
 	check_library MP4 "" "-lmp4v2 -lfaad -lm"
 

--- a/configure
+++ b/configure
@@ -406,6 +406,15 @@ check_roar()
 	return $?
 }
 
+ts_mp4v2_code="
+#include <mp4v2/mp4v2.h>
+
+int main() { 
+	MP4Read("/dev/null"); 
+	return 0; 
+}
+"
+
 check_mp4()
 {
 	USE_MPEG4IP=1
@@ -414,6 +423,8 @@ check_mp4()
 	if check_header mp4v2/mp4v2.h
 	then
 		USE_MPEG4IP=0
+		check_header neaacdec.h &&
+		check_library MP4 "" "-lmp4v2 -lfaad -lm"
 	else
 		# techsmith cripples the mp4v2 api so badly that we can't even check for
 		# headers, as the C++ causes any call to gcc to just fail. If the header
@@ -424,17 +435,14 @@ check_mp4()
 		if try_link -lmp4v2
 		then
 			msg_result yes
-			return $?
+			USE_MPEG4IP=0
+			IS_TS_MP4V2=1
+			check_header neaacdec.h &&
+			check_library MP4 "" "-lmp4v2 -lfaad -lm"
 		else
 			msg_result no
-			return $?
 		fi
 	fi
-
-	echo "GJUIKLP;SWEANFUIJ BJAESGFBUIYO"
-
-	check_header neaacdec.h &&
-	check_library MP4 "" "-lmp4v2 -lfaad -lm"
 
 	return $?
 }

--- a/configure
+++ b/configure
@@ -420,32 +420,19 @@ check_mp4()
 	USE_MPEG4IP=1
 	IS_TS_MP4V2=0
 
-	if check_header mp4v2/mp4v2.h "-lmp4v2"
+	if check_header mp4v2/mp4v2.h
 	then
+		echo "GJKBEFSBJUIKEFRWbjnuiaefgwuibo"
 		USE_MPEG4IP=0
 	else
-		# make sure that mp4v2 isn't hiding under an mp4.h header
-		if check_header mp4.h "-lmp4v2"
-		then
-			USE_MPEG4IP=1
-		else
-			# techsmith cripples the mp4v2 api so badly that we can't even check for
-			# headers, as the C++ causes any call to gcc to just fail. If the header
-			# check fails but mp4v2 is still linkable, assume that we the system has
-			# the techsmith fork and mark it as such.
-			msg_checking "for techsmith mp4v2 fork"
-
-			if try_link -lmp4v2
-			then
-				msg_result yes
-				USE_MPEG4IP=0
-				IS_TS_MP4V2=1
-			else
-				msg_result no
-				return $?
-			fi
-		fi
+		# techsmith cripples the mp4v2 api so badly that we can't even check for
+		# headers, as the C++ causes any call to gcc to just fail. If the header
+		# check fails but mp4v2 is still linkable, assume that we the system has
+		# the techsmith fork and mark it as such.
+    check_header mp4.h || return $?
 	fi
+
+	echo "GJKBEFSBJUIKEFRWbjnuiaefgwuibo"
 
 	check_header neaacdec.h &&
 	check_library MP4 "" "-lmp4v2 -lfaad -lm"

--- a/configure
+++ b/configure
@@ -420,12 +420,12 @@ check_mp4()
 	USE_MPEG4IP=1
 	IS_TS_MP4V2=0
 
-	if check_header mp4v2/mp4v2.h
+	if check_header mp4v2/mp4v2.h "-lmp4v2"
 	then
 		USE_MPEG4IP=0
 	else
 		# make sure that mp4v2 isn't hiding under an mp4.h header
-		if check_header mp4.h
+		if check_header mp4.h "-lmp4v2"
 		then
 			USE_MPEG4IP=1
 		else

--- a/configure
+++ b/configure
@@ -406,17 +406,50 @@ check_roar()
 	return $?
 }
 
+ts_mp4v2_code="
+#include <mp4v2/mp4v2.h>
+
+int main() { 
+	MP4Read("/dev/null"); 
+	return 0; 
+}
+"
+
 check_mp4()
 {
 	USE_MPEG4IP=1
+	IS_TS_MP4V2=0
+
 	if check_header mp4v2/mp4v2.h
 	then
 		USE_MPEG4IP=0
 	else
-		check_header mp4.h || return $?
+		# make sure that mp4v2 isn't hiding under an mp4.h header
+		if check_header mp4.h
+		then
+			USE_MPEG4IP=1
+		else
+			# techsmith cripples the mp4v2 api so badly that we can't even check for
+			# headers, as the C++ causes any call to gcc to just fail. If the header
+			# check fails but mp4v2 is still linkable, assume that we the system has
+			# the techsmith fork and mark it as such.
+			msg_checking "for techsmith mp4v2 fork"
+
+			if try_link -lmp4v2
+			then
+				msg_result yes
+				USE_MPEG4IP=0
+				IS_TS_MP4V2=1
+			else
+				msg_result no
+				return $?
+			fi
+		fi
 	fi
+
 	check_header neaacdec.h &&
 	check_library MP4 "" "-lmp4v2 -lfaad -lm"
+
 	return $?
 }
 
@@ -597,7 +630,7 @@ check check_jack       CONFIG_JACK
 check check_samplerate CONFIG_SAMPLERATE
 check check_ao         CONFIG_AO
 check check_coreaudio  CONFIG_COREAUDIO
-check check_arts       CONFIG_ARTS
+check check_arts       CONFIG_ARTST
 check check_oss        CONFIG_OSS
 check check_sndio      CONFIG_SNDIO
 check check_sun        CONFIG_SUN
@@ -626,7 +659,7 @@ config_header config/debug.h DEBUG
 config_header config/tremor.h CONFIG_TREMOR
 config_header config/modplug.h MODPLUG_API_8
 config_header config/mpc.h MPC_SV8
-config_header config/mp4.h USE_MPEG4IP
+config_header config/mp4.h USE_MPEG4IP IS_TS_MP4V2
 config_header config/curses.h HAVE_RESIZETERM HAVE_USE_DEFAULT_COLORS
 config_header config/ffmpeg.h HAVE_FFMPEG_AVCODEC_H USE_FALLBACK_IP
 config_header config/utils.h HAVE_BYTESWAP_H

--- a/configure
+++ b/configure
@@ -406,15 +406,6 @@ check_roar()
 	return $?
 }
 
-ts_mp4v2_code="
-#include <mp4v2/mp4v2.h>
-
-int main() { 
-	MP4Read("/dev/null"); 
-	return 0; 
-}
-"
-
 check_mp4()
 {
 	USE_MPEG4IP=1
@@ -422,17 +413,24 @@ check_mp4()
 
 	if check_header mp4v2/mp4v2.h
 	then
-		echo "GJKBEFSBJUIKEFRWbjnuiaefgwuibo"
 		USE_MPEG4IP=0
 	else
 		# techsmith cripples the mp4v2 api so badly that we can't even check for
 		# headers, as the C++ causes any call to gcc to just fail. If the header
 		# check fails but mp4v2 is still linkable, assume that we the system has
 		# the techsmith fork and mark it as such.
-    check_header mp4.h || return $?
-	fi
+		msg_checking "for techsmith mp4v2 fork"
 
-	echo "GJKBEFSBJUIKEFRWbjnuiaefgwuibo"
+		if try_link -lmp4v2
+		then
+			msg_result yes
+			USE_MPEG4IP=0
+			IS_TS_MP4V2=1
+		else
+			msg_result no
+			return $?
+		fi
+	fi
 
 	check_header neaacdec.h &&
 	check_library MP4 "" "-lmp4v2 -lfaad -lm"

--- a/ip/mp4.c
+++ b/ip/mp4.c
@@ -171,12 +171,7 @@ static int mp4_open(struct input_plugin_data *ip_data)
 	NeAACDecSetConfiguration(priv->decoder, neaac_cfg);
 
 	/* open mpeg-4 file */
-#ifdef __APPLE__
-	/* MP4Read doesnt have a second argument on macos */
-	priv->mp4.handle = MP4Read(ip_data->filename);
-#else
 	priv->mp4.handle = MP4Read(ip_data->filename, NULL);
-#endif
 
 	if (!priv->mp4.handle) {
 		d_print("MP4Read failed\n");

--- a/ip/mp4.c
+++ b/ip/mp4.c
@@ -171,7 +171,12 @@ static int mp4_open(struct input_plugin_data *ip_data)
 	NeAACDecSetConfiguration(priv->decoder, neaac_cfg);
 
 	/* open mpeg-4 file */
+#ifdef __APPLE__
+	/* MP4Read doesnt have a second argument on macos */
+	priv->mp4.handle = MP4Read(ip_data->filename);
+#else
 	priv->mp4.handle = MP4Read(ip_data->filename, NULL);
+#endif
 
 	if (!priv->mp4.handle) {
 		d_print("MP4Read failed\n");

--- a/ip/mp4.c
+++ b/ip/mp4.c
@@ -171,11 +171,8 @@ static int mp4_open(struct input_plugin_data *ip_data)
 	NeAACDecSetConfiguration(priv->decoder, neaac_cfg);
 
 	/* open mpeg-4 file */
-#ifdef MP4_DETAILS_ALL
-	priv->mp4.handle = MP4Read(ip_data->filename, 0);
-#else
-	priv->mp4.handle = MP4Read(ip_data->filename);
-#endif
+	priv->mp4.handle = MP4Read(ip_data->filename, NULL);
+	
 	if (!priv->mp4.handle) {
 		d_print("MP4Read failed\n");
 		goto out;

--- a/ip/mp4.c
+++ b/ip/mp4.c
@@ -171,9 +171,8 @@ static int mp4_open(struct input_plugin_data *ip_data)
 	NeAACDecSetConfiguration(priv->decoder, neaac_cfg);
 
 	/* open mpeg-4 file */
-
 #ifdef __APPLE__
-	/* libmp4v2 on Mac-OS doesnt have a second argument for some reason */
+	/* MP4Read doesnt have a second argument on macos */
 	priv->mp4.handle = MP4Read(ip_data->filename);
 #else
 	priv->mp4.handle = MP4Read(ip_data->filename, NULL);

--- a/ip/mp4.c
+++ b/ip/mp4.c
@@ -171,15 +171,15 @@ static int mp4_open(struct input_plugin_data *ip_data)
 	NeAACDecSetConfiguration(priv->decoder, neaac_cfg);
 
 	/* open mpeg-4 file */
-#if MP4V2_PROJECT_version_major < 2 ||  (MP4V2_PROJECT_version_major == 2 && MP4V2_PROJECT_version_minor < 1)
-	priv->mp4.handle = MP4Read(ip_data->filename);
-#else
+#if IS_TS_MP4V2
 	/* some distributions [notably arch linux] use techsmith's mp4v2 fork instead of the largely abandoned
 	   upstream project. This fork however is primarily designed for internal techsmith use, and in 4.1.4/4.1.5
 	   they added an extra argument to MP4Read that when dynamically called my cmus would result in a segfault.
 	   to fix this, we check if we are using the techsmith fork by seeing if the version is higher than the last
 	   upstream version, and then specify the argument in that case. */
 	priv->mp4.handle = MP4Read(ip_data->filename, NULL);
+#else
+	priv->mp4.handle = MP4Read(ip_data->filename);
 #endif
 
 	if (!priv->mp4.handle) {

--- a/ip/mp4.c
+++ b/ip/mp4.c
@@ -171,7 +171,12 @@ static int mp4_open(struct input_plugin_data *ip_data)
 	NeAACDecSetConfiguration(priv->decoder, neaac_cfg);
 
 	/* open mpeg-4 file */
-	priv->mp4.handle =  (MP4FileHandle (*)(void*, void*))(&MP4Read)(ip_data->filename, NULL);
+
+#ifdef __APPLE__
+	/* libmp4v2 on Mac-OS doesnt have a second argument for some reason */
+	priv->mp4.handle = MP4Read(ip_data->filename);
+#else
+	priv->mp4.handle = MP4Read(ip_data->filename, NULL);
 
 	if (!priv->mp4.handle) {
 		d_print("MP4Read failed\n");

--- a/ip/mp4.c
+++ b/ip/mp4.c
@@ -172,9 +172,13 @@ static int mp4_open(struct input_plugin_data *ip_data)
 
 	/* open mpeg-4 file */
 #if MP4V2_PROJECT_version_major < 2 ||  (MP4V2_PROJECT_version_major == 2 && MP4V2_PROJECT_version_minor < 1)
-	/* MP4Read doesnt have a second argument on macos */
 	priv->mp4.handle = MP4Read(ip_data->filename);
 #else
+	/* some distributions [notably arch linux] use techsmith's mp4v2 fork instead of the largely abandoned
+	   upstream project. This fork however is primarily designed for internal techsmith use, and in 4.1.4/4.1.5
+	   they added an extra argument to MP4Read that when dynamically called my cmus would result in a segfault.
+	   to fix this, we check if we are using the techsmith fork by seeing if the version is higher than the last
+	   upstream version, and then specify the argument in that case. */
 	priv->mp4.handle = MP4Read(ip_data->filename, NULL);
 #endif
 

--- a/ip/mp4.c
+++ b/ip/mp4.c
@@ -177,6 +177,7 @@ static int mp4_open(struct input_plugin_data *ip_data)
 	priv->mp4.handle = MP4Read(ip_data->filename);
 #else
 	priv->mp4.handle = MP4Read(ip_data->filename, NULL);
+#endif
 
 	if (!priv->mp4.handle) {
 		d_print("MP4Read failed\n");

--- a/ip/mp4.c
+++ b/ip/mp4.c
@@ -171,8 +171,12 @@ static int mp4_open(struct input_plugin_data *ip_data)
 	NeAACDecSetConfiguration(priv->decoder, neaac_cfg);
 
 	/* open mpeg-4 file */
-	priv->mp4.handle = MP4Read(ip_data->filename, NULL);
-	
+#ifdef MP4_DETAILS_ALL
+	priv->mp4.handle = MP4Read(ip_data->filename, 0);
+#else
+	priv->mp4.handle = (*)(void*, void*)(&MP4Read)(ip_data->filename, NULL);
+#endif
+
 	if (!priv->mp4.handle) {
 		d_print("MP4Read failed\n");
 		goto out;

--- a/ip/mp4.c
+++ b/ip/mp4.c
@@ -171,11 +171,7 @@ static int mp4_open(struct input_plugin_data *ip_data)
 	NeAACDecSetConfiguration(priv->decoder, neaac_cfg);
 
 	/* open mpeg-4 file */
-#ifdef MP4_DETAILS_ALL
-	priv->mp4.handle = MP4Read(ip_data->filename, 0);
-#else
-	priv->mp4.handle = (*)(void*, void*)(&MP4Read)(ip_data->filename, NULL);
-#endif
+	priv->mp4.handle =  (MP4FileHandle (*)(void*, void*))(&MP4Read)(ip_data->filename, NULL);
 
 	if (!priv->mp4.handle) {
 		d_print("MP4Read failed\n");

--- a/ip/mp4.c
+++ b/ip/mp4.c
@@ -171,7 +171,7 @@ static int mp4_open(struct input_plugin_data *ip_data)
 	NeAACDecSetConfiguration(priv->decoder, neaac_cfg);
 
 	/* open mpeg-4 file */
-#ifdef __APPLE__
+#if MP4V2_PROJECT_version_major < 2 ||  (MP4V2_PROJECT_version_major == 2 && MP4V2_PROJECT_version_minor < 1)
 	/* MP4Read doesnt have a second argument on macos */
 	priv->mp4.handle = MP4Read(ip_data->filename);
 #else

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -613,7 +613,7 @@ check_header()
 	__header="$1"
 	shift
 	msg_checking "for header <$__header>"
-	if try_compile "#include <$__header>" "$@"
+	if try_compile_link "#include <$__header>" "$@"
 	then
 		msg_result yes
 		return 0


### PR DESCRIPTION
Cmus will encounter a segmentation fault reading mp4/m4a/m4b if the shared `libmp4v2` library is at v4.1.4+. This is because that release changed the `MP4Read` function from an overloaded method to a single method with a default argument of `nullptr`, causing cmus to segfault when it only specified one argument. 

This PR fixes that by changing the function call to specify `NULL` as the second argument, which prevents cmus from segfaulting.

Fixes #1076.

Related: [mp4v2/#47](https://github.com/TechSmith/mp4v2/issues/47)

Feel free to raise any concerns with this fix.