### PR TITLE
Initialize active to zero in print_editable

### DIFF
--- a/ui_curses.c
+++ b/ui_curses.c
@@ -763,7 +763,7 @@ static void print_editable(struct window *win, int row, struct iter *iter)
 {
 	struct simple_track *track;
 	struct iter sel;
-	int current, selected, active;
+	int current, selected, active = 0;
 	const char *format;
 
 	track = iter_to_simple_track(iter);
@@ -776,7 +776,7 @@ static void print_editable(struct window *win, int row, struct iter *iter)
 		cursor_y = 1 + row;
 	}
 
-	if (!selected && track->marked) {
+	if (!selected && !!track->marked) {
 		selected = 1;
 		active = 0;
 	}


### PR DESCRIPTION
The uninitialized variable, active, would sometimes cause cmus to segfault while accessing the pairs array based on its value.

This commit also fixes implementation-defined behaviour for the implicit cast of track->marked.

fixes #1093