### PR TITLE
Fix segfault

### DIFF
--- a/format_print.c
+++ b/format_print.c
@@ -44,6 +44,9 @@ static struct gbuf* str = &l_str;
 
 size_t mark_clipped_text(char *buffer, int buf_len)
 {
+	if (buf_len < 0) {
+		return 0;
+	}
 	int clipped_mark_len = min_u(u_str_width(clipped_text_internal), buf_len);
 	int skip = buf_len - clipped_mark_len;
 	size_t byte_pos = u_skip_chars(buffer, &skip, false);


### PR DESCRIPTION
Hi,

I got segfault, because this mark_clipped_text function got negative buffer length. This is simple fix, but it works for me. Maybe there is a worse bug, which originates the negative buffer_length. I don't have knowledge about cmus's codebase to go hunting for it, so here is what I got.