### PR TITLE
Handle colors in active windows correctly

### DIFF
--- a/ui_curses.c
+++ b/ui_curses.c
@@ -141,6 +141,7 @@ static int track_win_w = 0;
 
 static int win_x = 0;
 static int win_w = 0;
+static int win_active = 1;
 
 static int show_cursor;
 static int cursor_x;
@@ -763,7 +764,7 @@ static void print_editable(struct window *win, int row, struct iter *iter)
 {
 	struct simple_track *track;
 	struct iter sel;
-	int current, selected, active = 0;
+	int current, selected, active;
 	const char *format;
 
 	track = iter_to_simple_track(iter);
@@ -776,6 +777,7 @@ static void print_editable(struct window *win, int row, struct iter *iter)
 		cursor_y = 1 + row;
 	}
 
+	active = win_active;
 	if (!selected && !!track->marked) {
 		selected = 1;
 		active = 0;
@@ -1002,6 +1004,7 @@ static void update_pl_tracks(struct window *win)
 
 	win_x = track_win_x;
 	win_w = track_win_w;
+	win_active = pl_get_cursor_in_track_window();
 
 	get_global_fopts();
 	fopt_set_time(&track_fopts[TF_TOTAL], pl_visible_total_time(), 0);
@@ -1009,6 +1012,7 @@ static void update_pl_tracks(struct window *win)
 	format_print(title, track_win_w - 2, "Track%= %{total}", track_fopts);
 	update_window(win, track_win_x, 0, track_win_w, title, print_editable);
 
+	win_active = 1;
 	win_x = 0;
 	win_w = win_w_tmp;
 }


### PR DESCRIPTION
Originally, there was the editable_active variable in ui_curses.c to
indicate whether the window is active. However, this variable was
removed in #1051, presumably by mistake. It also leads to the active
variable being uninitialized in print_editable, causing #1093.

The uninitialized variable issues was fixed in #1094, but unfortunately
in a wrong way: it simply assumes all windows are inactive, leading to
incorrect colors in many views.

This commit restores the old logic of editable_active (renamed to
win_active for consistency). Now the colors should be correct.