### PR TITLE
Implement pause_on_output_change option

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -1104,7 +1104,7 @@ output_plugin [roar, pulse, alsa, arts, oss, sndio, sun, coreaudio]
 pause_on_output_change (false)
     Pauses playback when the audio output changes.
 
-    Supported output plugins: none.
+    Supported output plugins: pulse.
 
 pl_sort () [`Sort Keys`]
 	Sort keys for the playlist view (3). Empty value disables sorting and

--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -1101,6 +1101,11 @@ mpris (true)
 output_plugin [roar, pulse, alsa, arts, oss, sndio, sun, coreaudio]
 	Name of output plugin.
 
+pause_on_output_change (false)
+    Pauses playback when the audio output changes.
+
+    Supported output plugins: none.
+
 pl_sort () [`Sort Keys`]
 	Sort keys for the playlist view (3). Empty value disables sorting and
 	enables manually moving tracks.

--- a/mixer.h
+++ b/mixer.h
@@ -25,12 +25,17 @@
 
 #define NR_MIXER_FDS 4
 
+enum {
+    /* volume changes */
+    MIXER_FDS_VOLUME
+};
+
 struct mixer_plugin_ops {
 	int (*init)(void);
 	int (*exit)(void);
 	int (*open)(int *volume_max);
 	int (*close)(void);
-	int (*get_fds)(int *fds);
+	int (*get_fds)(int what, int *fds);
 	int (*set_volume)(int l, int r);
 	int (*get_volume)(int *l, int *r);
 };

--- a/mixer.h
+++ b/mixer.h
@@ -35,7 +35,10 @@ struct mixer_plugin_ops {
 	int (*exit)(void);
 	int (*open)(int *volume_max);
 	int (*close)(void);
-	int (*get_fds)(int what, int *fds);
+	union {
+	    int (*abi_1)(int *fds); // MIXER_FDS_VOLUME
+	    int (*abi_2)(int what, int *fds);
+	} get_fds;
 	int (*set_volume)(int l, int r);
 	int (*get_volume)(int *l, int *r);
 };

--- a/mixer.h
+++ b/mixer.h
@@ -27,7 +27,9 @@
 
 enum {
     /* volume changes */
-    MIXER_FDS_VOLUME
+    MIXER_FDS_VOLUME,
+    /* output changes */
+    MIXER_FDS_OUTPUT
 };
 
 struct mixer_plugin_ops {

--- a/op.h
+++ b/op.h
@@ -26,7 +26,7 @@
 #include <fcntl.h>
 #endif
 
-#define OP_ABI_VERSION 1
+#define OP_ABI_VERSION 2
 
 enum {
 	/* no error */

--- a/op/coreaudio.c
+++ b/op/coreaudio.c
@@ -957,13 +957,13 @@ const struct output_plugin_ops op_pcm_ops = {
 
 
 const struct mixer_plugin_ops op_mixer_ops = {
-	.init       = coreaudio_mixer_dummy,
-	.exit       = coreaudio_mixer_dummy,
-	.open       = coreaudio_mixer_open,
-	.close      = coreaudio_mixer_close,
-	.get_fds    = coreaudio_mixer_get_fds,
-	.set_volume = coreaudio_mixer_set_volume,
-	.get_volume = coreaudio_mixer_get_volume,
+	.init          = coreaudio_mixer_dummy,
+	.exit          = coreaudio_mixer_dummy,
+	.open          = coreaudio_mixer_open,
+	.close         = coreaudio_mixer_close,
+	.get_fds.abi_2 = coreaudio_mixer_get_fds,
+	.set_volume    = coreaudio_mixer_set_volume,
+	.get_volume    = coreaudio_mixer_get_volume,
 };
 
 const struct output_plugin_opt op_pcm_options[] = {

--- a/op/coreaudio.c
+++ b/op/coreaudio.c
@@ -864,10 +864,15 @@ static int coreaudio_mixer_dummy(void)
 	return OP_ERROR_SUCCESS;
 }
 
-static int coreaudio_mixer_get_fds(int *fds)
+static int coreaudio_mixer_get_fds(int what, int *fds)
 {
-	fds[0] = coreaudio_mixer_pipe_out;
-	return 1;
+	switch (what) {
+	case MIXER_FDS_VOLUME:
+		fds[0] = coreaudio_mixer_pipe_out;
+		return 1;
+	default:
+		return 0;
+	}
 }
 
 static int coreaudio_pause(void)

--- a/op/mixer_alsa.c
+++ b/op/mixer_alsa.c
@@ -218,7 +218,7 @@ const struct mixer_plugin_ops op_mixer_ops = {
 	.exit = alsa_mixer_exit,
 	.open = alsa_mixer_open,
 	.close = alsa_mixer_close,
-	.get_fds = alsa_mixer_get_fds,
+	.get_fds.abi_2 = alsa_mixer_get_fds,
 	.set_volume = alsa_mixer_set_volume,
 	.get_volume = alsa_mixer_get_volume,
 };

--- a/op/mixer_alsa.c
+++ b/op/mixer_alsa.c
@@ -137,15 +137,20 @@ static int alsa_mixer_close(void)
 	return 0;
 }
 
-static int alsa_mixer_get_fds(int *fds)
+static int alsa_mixer_get_fds(int what, int *fds)
 {
 	struct pollfd pfd[NR_MIXER_FDS];
 	int count, i;
 
-	count = snd_mixer_poll_descriptors(alsa_mixer_handle, pfd, NR_MIXER_FDS);
-	for (i = 0; i < count; i++)
-		fds[i] = pfd[i].fd;
-	return count;
+	switch (what) {
+	case MIXER_FDS_VOLUME:
+		count = snd_mixer_poll_descriptors(alsa_mixer_handle, pfd, NR_MIXER_FDS);
+		for (i = 0; i < count; i++)
+			fds[i] = pfd[i].fd;
+		return count;
+	default:
+		return 0;
+	}
 }
 
 static int alsa_mixer_set_volume(int l, int r)

--- a/op/pulse.c
+++ b/op/pulse.c
@@ -606,7 +606,7 @@ const struct mixer_plugin_ops op_mixer_ops = {
 	.exit		= op_pulse_mixer_exit,
 	.open		= op_pulse_mixer_open,
 	.close		= op_pulse_mixer_close,
-	.get_fds	= op_pulse_mixer_get_fds,
+	.get_fds.abi_2	= op_pulse_mixer_get_fds,
 	.set_volume	= op_pulse_mixer_set_volume,
 	.get_volume	= op_pulse_mixer_get_volume,
 };

--- a/op/pulse.c
+++ b/op/pulse.c
@@ -524,10 +524,15 @@ static int op_pulse_mixer_close(void)
 	return OP_ERROR_SUCCESS;
 }
 
-static int op_pulse_mixer_get_fds(int *fds)
+static int op_pulse_mixer_get_fds(int what, int *fds)
 {
-	fds[0] = mixer_notify_out;
-	return 1;
+	switch (what) {
+	case MIXER_FDS_VOLUME:
+		fds[0] = mixer_notify_out;
+		return 1;
+	default:
+		return 0;
+	}
 }
 
 static int op_pulse_mixer_set_volume(int l, int r)

--- a/options.c
+++ b/options.c
@@ -87,6 +87,7 @@ int start_view = TREE_VIEW;
 int stop_after_queue = 0;
 int tree_width_percent = 33;
 int tree_width_max = 0;
+int pause_on_output_change = 0;
 
 int colors[NR_COLORS] = {
 	-1,
@@ -1215,6 +1216,21 @@ static void toggle_stop_after_queue(void *data)
 	stop_after_queue ^= 1;
 }
 
+static void get_pause_on_output_change(void *data, char *buf, size_t size)
+{
+	strscpy(buf, bool_names[pause_on_output_change], size);
+}
+
+static void set_pause_on_output_change(void *data, const char *buf)
+{
+	parse_bool(buf, &pause_on_output_change);
+}
+
+static void toggle_pause_on_output_change(void *data)
+{
+	pause_on_output_change ^= 1;
+}
+
 /* }}} */
 
 /* special callbacks (id set) {{{ */
@@ -1465,6 +1481,7 @@ static const struct {
 	DT(stop_after_queue)
 	DN(tree_width_percent)
 	DN(tree_width_max)
+	DT(pause_on_output_change)
 	{ NULL, NULL, NULL, NULL, 0 }
 };
 

--- a/options.h
+++ b/options.h
@@ -160,6 +160,7 @@ extern int start_view;
 extern int stop_after_queue;
 extern int tree_width_percent;
 extern int tree_width_max;
+extern int pause_on_output_change;
 
 extern const char * const aaa_mode_names[];
 extern const char * const view_names[NR_VIEWS + 1];

--- a/output.c
+++ b/output.c
@@ -43,6 +43,7 @@ struct output_plugin {
 	char *name;
 	void *handle;
 
+	const unsigned *abi_version_ptr;
 	const struct output_plugin_ops *pcm_ops;
 	const struct mixer_plugin_ops *mixer_ops;
 	const struct output_plugin_opt *pcm_options;
@@ -95,7 +96,6 @@ void op_load_plugins(void)
 		struct output_plugin *plug;
 		void *so, *symptr;
 		char *ext;
-		const unsigned *abi_version_ptr;
 		bool err = false;
 
 		if (d->d_name[0] == '.')
@@ -119,12 +119,13 @@ void op_load_plugins(void)
 		plug->pcm_ops = dlsym(so, "op_pcm_ops");
 		plug->pcm_options = dlsym(so, "op_pcm_options");
 		symptr = dlsym(so, "op_priority");
-		abi_version_ptr = dlsym(so, "op_abi_version");
+		plug->abi_version_ptr = dlsym(so, "op_abi_version");
 		if (!plug->pcm_ops || !plug->pcm_options || !symptr) {
 			error_msg("%s: missing symbol", filename);
 			err = true;
 		}
-		if (!abi_version_ptr || *abi_version_ptr != OP_ABI_VERSION) {
+		STATIC_ASSERT(OP_ABI_VERSION == 2);
+		if (!plug->abi_version_ptr || (*plug->abi_version_ptr != 1 && *plug->abi_version_ptr != 2)) {
 			error_msg("%s: incompatible plugin version", filename);
 			err = true;
 		}
@@ -322,9 +323,18 @@ int mixer_get_fds(int what, int *fds)
 		return -OP_ERROR_NOT_INITIALIZED;
 	if (!op->mixer_open)
 		return -OP_ERROR_NOT_OPEN;
-	if (!op->mixer_ops->get_fds)
-		return -OP_ERROR_NOT_SUPPORTED;
-	return op->mixer_ops->get_fds(what, fds);
+	switch (*op->abi_version_ptr) {
+	case 1:
+		if (!op->mixer_ops->get_fds.abi_1)
+			return -OP_ERROR_NOT_SUPPORTED;
+		if (what != MIXER_FDS_VOLUME)
+			return 0;
+		return op->mixer_ops->get_fds.abi_1(fds);
+	default:
+		if (!op->mixer_ops->get_fds.abi_2)
+			return -OP_ERROR_NOT_SUPPORTED;
+		return op->mixer_ops->get_fds.abi_2(what, fds);
+	}
 }
 
 extern int soft_vol;

--- a/output.c
+++ b/output.c
@@ -316,7 +316,7 @@ int mixer_read_volume(void)
 	return op->mixer_ops->get_volume(&volume_l, &volume_r);
 }
 
-int mixer_get_fds(int *fds)
+int mixer_get_fds(int what, int *fds)
 {
 	if (op == NULL)
 		return -OP_ERROR_NOT_INITIALIZED;
@@ -324,7 +324,7 @@ int mixer_get_fds(int *fds)
 		return -OP_ERROR_NOT_OPEN;
 	if (!op->mixer_ops->get_fds)
 		return -OP_ERROR_NOT_SUPPORTED;
-	return op->mixer_ops->get_fds(fds);
+	return op->mixer_ops->get_fds(what, fds);
 }
 
 extern int soft_vol;

--- a/output.h
+++ b/output.h
@@ -85,7 +85,7 @@ void mixer_open(void);
 void mixer_close(void);
 int mixer_set_volume(int left, int right);
 int mixer_read_volume(void);
-int mixer_get_fds(int *fds);
+int mixer_get_fds(int what, int *fds);
 
 void op_add_options(void);
 char *op_get_error_msg(int rc, const char *arg);

--- a/ui_curses.c
+++ b/ui_curses.c
@@ -2138,8 +2138,8 @@ static void main_loop(void)
 		fd_set set;
 		struct timeval tv;
 		int poll_mixer = 0;
-		int i, nr_fds = 0;
-		int fds[NR_MIXER_FDS];
+		int i;
+		int nr_fds_vol = 0, fds_vol[NR_MIXER_FDS];
 		struct list_head *item;
 		struct client *client;
 
@@ -2174,15 +2174,15 @@ static void main_loop(void)
 			SELECT_ADD_FD(client->fd);
 		}
 		if (!soft_vol) {
-			nr_fds = mixer_get_fds(fds);
-			if (nr_fds <= 0) {
+			nr_fds_vol = mixer_get_fds(MIXER_FDS_VOLUME, fds_vol);
+			if (nr_fds_vol <= 0) {
 				poll_mixer = 1;
 				if (!tv.tv_usec)
 					tv.tv_usec = 500e3;
 			}
-			for (i = 0; i < nr_fds; i++) {
-				BUG_ON(fds[i] <= 0);
-				SELECT_ADD_FD(fds[i]);
+			for (i = 0; i < nr_fds_vol; i++) {
+				BUG_ON(fds_vol[i] <= 0);
+				SELECT_ADD_FD(fds_vol[i]);
 			}
 		}
 
@@ -2207,8 +2207,8 @@ static void main_loop(void)
 			continue;
 		}
 
-		for (i = 0; i < nr_fds; i++) {
-			if (FD_ISSET(fds[i], &set)) {
+		for (i = 0; i < nr_fds_vol; i++) {
+			if (FD_ISSET(fds_vol[i], &set)) {
 				d_print("vol changed\n");
 				mixer_read_volume();
 				mpris_volume_changed();


### PR DESCRIPTION
This also bumps the output plugin ABI to add support for returning multiple mixer FD lists, but preserves compatibility with older plugins.

closes #1139 

**Note:** @flyingmutant, when you merge this, please do a merge rather than a squash to keep the plugin changes separate.