### PR TITLE
Recognize artist/album sort keys from ffmpeg plugin

### DIFF
--- a/comment.c
+++ b/comment.c
@@ -232,6 +232,14 @@ static struct {
 	{ "sourcemedia", "media" },
 	{ "MusicBrainz Track Id", "musicbrainz_trackid" },
 	{ "version", "subtitle" },
+	/* ffmpeg id3 */
+	{ "artist-sort", "artistsort" },
+	{ "TSO2", "albumartistsort" },
+	{ "album-sort", "albumsort" },
+	/* ffmpeg mp4 */
+	{ "sort_artist", "artistsort" },
+	{ "sort_album_artist", "albumartistsort" },
+	{ "sort_album", "albumsort" },
 	{ NULL, NULL }
 };
 


### PR DESCRIPTION
These values are experimental. I've no explanation for why "TSO2" is
used rather than something like "album-artist-sort".

This is particularly relevant for mp4/m4a as the mp4 input plugin is
currently broken/disabled on many platforms.

Fixes #1164.