### PR TITLE
Workaround for #1064

### DIFF
--- a/op/pulse.c
+++ b/op/pulse.c
@@ -17,7 +17,9 @@
  */
 
 #include <string.h>
+#include <stdbool.h>
 
+#include <pulse/introspect.h>
 #include <pulse/pulseaudio.h>
 
 #include "../op.h"
@@ -32,6 +34,8 @@ static pa_stream		*pa_s;
 static pa_channel_map		 pa_cmap;
 static pa_cvolume		 pa_vol;
 static pa_sample_spec		 pa_ss;
+
+static bool 		 is_pipewire = false;
 
 static int			 mixer_notify_in;
 static int			 mixer_notify_out;
@@ -175,6 +179,20 @@ static void _pa_sink_input_info_cb(pa_context *c,
 	}
 }
 
+static void _pa_server_info_cb(pa_context *c,
+					const pa_server_info *i,
+					void *data)
+{
+	is_pipewire = false;
+	if (i) {
+		if (strstr(i->server_name, "PipeWire") != NULL) {
+			// server is PipeWire
+			d_print("Pulseaudio server is pipewire. Disabling _pa_stream_drain()\n");
+			is_pipewire = true;
+		}
+	}
+}
+
 static void _pa_stream_success_cb(pa_stream *s, int success, void *data)
 {
 	pa_threaded_mainloop_signal(pa_ml, 0);
@@ -246,6 +264,10 @@ static int _pa_stream_cork(int pause_)
 
 static int _pa_stream_drain(void)
 {
+	if (is_pipewire) {
+		return OP_ERROR_SUCCESS;
+	}
+
 	pa_threaded_mainloop_lock(pa_ml);
 
 	return _pa_wait_unlock(pa_stream_drain(pa_s, _pa_stream_success_cb, NULL));
@@ -422,6 +444,8 @@ static int op_pulse_open(sample_format_t sf, const channel_position_t *channel_m
 	pa_context_get_sink_input_info(pa_ctx, pa_stream_get_index(pa_s),
 			_pa_sink_input_info_cb, NULL);
 
+	pa_context_get_server_info(pa_ctx, _pa_server_info_cb, NULL);
+
 	pa_threaded_mainloop_unlock(pa_ml);
 
 	return OP_ERROR_SUCCESS;
@@ -440,8 +464,10 @@ static int op_pulse_close(void)
 	 * If this _pa_stream_drain() will be moved below following
 	 * pa_threaded_mainloop_lock(), PulseAudio 0.9.19 will hang.
 	 */
-	if (pa_s)
+
+	if (pa_s && !is_pipewire){
 		_pa_stream_drain();
+	}
 
 	pa_threaded_mainloop_lock(pa_ml);
 

--- a/op/pulse.c
+++ b/op/pulse.c
@@ -35,7 +35,7 @@ static pa_channel_map		 pa_cmap;
 static pa_cvolume		 pa_vol;
 static pa_sample_spec		 pa_ss;
 
-static bool 		 is_pipewire = false;
+static bool			 is_pipewire = false;
 
 static int			 mixer_notify_in;
 static int			 mixer_notify_out;
@@ -180,8 +180,8 @@ static void _pa_sink_input_info_cb(pa_context *c,
 }
 
 static void _pa_server_info_cb(pa_context *c,
-					const pa_server_info *i,
-					void *data)
+			       const pa_server_info *i,
+			       void *data)
 {
 	is_pipewire = false;
 	if (i) {
@@ -264,10 +264,6 @@ static int _pa_stream_cork(int pause_)
 
 static int _pa_stream_drain(void)
 {
-	if (is_pipewire) {
-		return OP_ERROR_SUCCESS;
-	}
-
 	pa_threaded_mainloop_lock(pa_ml);
 
 	return _pa_wait_unlock(pa_stream_drain(pa_s, _pa_stream_success_cb, NULL));


### PR DESCRIPTION
I noticed that from probably PipeWire 0.3.34 up to now, cmus started taking a long time before exiting when the music is paused (#1064), otherwise it has no issue. It seems like disabling `_pa_stream_drain` on PipeWire when exiting cmus fixes the issue and has no apparent setbacks. This seems to be an issue with upstream (as it was once fixed there), but given the simplicity of the workaround, we can have this until upstream fixes the issue.