### PR TITLE
Add support for .nomedia file

### DIFF
--- a/job.c
+++ b/job.c
@@ -283,6 +283,11 @@ static void add_dir(const char *dirname, const char *root)
 		struct dir_entry *ent;
 		int size;
 
+		if (strcmp(name, ".nomusic") == 0 || strcmp(name, ".nomedia") == 0) {
+			ptr_array_clear(&array);
+			break;
+		}
+
 		if (name[0] == '.')
 			continue;
 

--- a/load_dir.h
+++ b/load_dir.h
@@ -82,4 +82,17 @@ static inline void ptr_array_unique(struct ptr_array *array,
 	array->count = j;
 }
 
+static inline void ptr_array_clear(struct ptr_array *array)
+{
+	void **ptrs = array->ptrs;
+
+	for (int i = 0; i != array->count; i++) {
+		free(ptrs[i]);
+	}
+	free(ptrs);
+	array->ptrs = NULL;
+	array->alloc = 0;
+	array->count = 0;
+}
+
 #endif


### PR DESCRIPTION
When adding directories, ignore folders that contains a .nomedia file.

This mimics the convention of the Android OS[1] to tell smartphone apps
not to display or include the contents of the folder, which is also
supported by different Desktop programs[2] and other multimedia
platforms[3]

[1] https://en.wikipedia.org/wiki/Hidden_file_and_hidden_directory#Android
[2]
   * https://forum.strawberrymusicplayer.org/topic/412/exclude-paths-directories-files-from-library/2?_=1652534386411&lang=en-US
   * https://github.com/clementine-player/Clementine/pull/5327
[3] https://kodi.wiki/view/Update_Music_Library#Exclude_Folder