### PR TITLE
Take opus output gain into account when checking replaygain_limit peak

### DIFF
--- a/comment.c
+++ b/comment.c
@@ -205,6 +205,7 @@ static const char *interesting[] = {
 	"replaygain_track_peak",
 	"replaygain_album_gain",
 	"replaygain_album_peak",
+	"output_gain",
 	"musicbrainz_trackid",
 	"comment",
 	"bpm",

--- a/comment.c
+++ b/comment.c
@@ -205,7 +205,6 @@ static const char *interesting[] = {
 	"replaygain_track_peak",
 	"replaygain_album_gain",
 	"replaygain_album_peak",
-	"output_gain",
 	"musicbrainz_trackid",
 	"comment",
 	"bpm",

--- a/ip/opus.c
+++ b/ip/opus.c
@@ -239,8 +239,7 @@ static int opus_read_comments(struct input_plugin_data *ip_data,
 
 	head = op_head(priv->of, -1);
 	if(head != NULL) {
-		char *val = xmalloc(12); // 11 max int digits + NULL
-		memset(val, 0, 12);
+		char *val = xmalloc0(12); // 11 max int digits + NULL
 
 		snprintf(val, 12, "%d", head->output_gain);
 		keyvals_add(&c, "output_gain", val);

--- a/ip/opus.c
+++ b/ip/opus.c
@@ -265,6 +265,9 @@ static int opus_read_comments(struct input_plugin_data *ip_data,
 			continue;
 		}
 
+		if (strncmp(str, "output_gain", 11) == 0)
+			continue;
+
 		key = xstrndup(str, eq - str);
 		comments_add_const(&c, key, eq + 1);
 		free(key);

--- a/ip/opus.c
+++ b/ip/opus.c
@@ -243,7 +243,6 @@ static int opus_read_comments(struct input_plugin_data *ip_data,
 
 		snprintf(val, 12, "%d", head->output_gain);
 		keyvals_add(&c, "output_gain", val);
-		free(val);
 	}
 
 	ot = op_tags(priv->of, -1);

--- a/ip/opus.c
+++ b/ip/opus.c
@@ -232,14 +232,26 @@ static int opus_read_comments(struct input_plugin_data *ip_data,
 	GROWING_KEYVALS(c);
 	struct opus_private *priv;
 	const OpusTags *ot;
+	const OpusHead *head;
 	int i;
 
 	priv = ip_data->private;
 
+	head = op_head(priv->of, -1);
+	if(head != NULL) {
+		char *val = xmalloc(12); // 11 max int digits + NULL
+		memset(val, 0, 12);
+
+		snprintf(val, 12, "%d", head->output_gain);
+		comments_add_const(&c, "output_gain", val);
+		free(val);
+	}
+
 	ot = op_tags(priv->of, -1);
 	if (ot == NULL) {
 		d_print("ot == NULL\n");
-		*comments = keyvals_new(0);
+		keyvals_terminate(&c);
+		*comments = c.keyvals;
 		return 0;
 	}
 

--- a/ip/opus.c
+++ b/ip/opus.c
@@ -243,7 +243,7 @@ static int opus_read_comments(struct input_plugin_data *ip_data,
 		memset(val, 0, 12);
 
 		snprintf(val, 12, "%d", head->output_gain);
-		comments_add_const(&c, "output_gain", val);
+		keyvals_add(&c, "output_gain", val);
 		free(val);
 	}
 
@@ -264,9 +264,6 @@ static int opus_read_comments(struct input_plugin_data *ip_data,
 			d_print("invalid comment: '%s' ('=' expected)\n", str);
 			continue;
 		}
-
-		if (strncmp(str, "output_gain", 11) == 0)
-			continue;
 
 		key = xstrndup(str, eq - str);
 		comments_add_const(&c, key, eq + 1);

--- a/player.c
+++ b/player.c
@@ -349,7 +349,7 @@ static void scale_samples(char *buffer, unsigned int *countp)
 
 static void update_rg_scale(void)
 {
-	double gain, peak, db, scale, check_scale, limit;
+	double gain, peak, db, scale, limit;
 
 	replaygain_scale = 1.0;
 	if (!player_info_priv.ti || !replaygain)
@@ -380,8 +380,8 @@ static void update_rg_scale(void)
 		return;
 	}
 	if (isnan(peak)) {
-		d_print("peak not available, defaulting to 1\n");
-		peak = 1;
+		d_print("peak not available, deriving from output gain\n");
+		peak = pow(10.0, player_info_priv.ti->output_gain / 20.0);
 	}
 	if (peak < 0.05) {
 		d_print("peak (%g) is too small\n", peak);
@@ -391,16 +391,15 @@ static void update_rg_scale(void)
 	db = replaygain_preamp + gain;
 
 	scale = pow(10.0, db / 20.0);
-	check_scale = pow(10.0, (db + player_info_priv.ti->output_gain) / 20.0);
 	replaygain_scale = scale;
 	limit = 1.0 / peak;
 	if (replaygain_limit && !isnan(peak)) {
-		if (check_scale > limit)
+		if (replaygain_scale > limit)
 			replaygain_scale = limit;
 	}
 
-	d_print("gain = %f, peak = %f, db = %f, scale = %f, check_scale = %f, limit = %f, replaygain_scale = %f\n",
-			gain, peak, db, scale, check_scale, limit, replaygain_scale);
+	d_print("gain = %f, peak = %f, db = %f, scale = %f, limit = %f, replaygain_scale = %f\n",
+			gain, peak, db, scale, limit, replaygain_scale);
 }
 
 static inline unsigned int buffer_second_size(void)

--- a/player.c
+++ b/player.c
@@ -349,7 +349,7 @@ static void scale_samples(char *buffer, unsigned int *countp)
 
 static void update_rg_scale(void)
 {
-	double gain, peak, db, scale, limit;
+	double gain, peak, db, scale, check_scale, limit;
 
 	replaygain_scale = 1.0;
 	if (!player_info_priv.ti || !replaygain)
@@ -391,15 +391,16 @@ static void update_rg_scale(void)
 	db = replaygain_preamp + gain;
 
 	scale = pow(10.0, db / 20.0);
+	check_scale = pow(10.0, (db + player_info_priv.ti->output_gain) / 20.0);
 	replaygain_scale = scale;
 	limit = 1.0 / peak;
 	if (replaygain_limit && !isnan(peak)) {
-		if (replaygain_scale > limit)
+		if (check_scale > limit)
 			replaygain_scale = limit;
 	}
 
-	d_print("gain = %f, peak = %f, db = %f, scale = %f, limit = %f, replaygain_scale = %f\n",
-			gain, peak, db, scale, limit, replaygain_scale);
+	d_print("gain = %f, peak = %f, db = %f, scale = %f, check_scale = %f, limit = %f, replaygain_scale = %f\n",
+			gain, peak, db, scale, check_scale, limit, replaygain_scale);
 }
 
 static inline unsigned int buffer_second_size(void)

--- a/track_info.c
+++ b/track_info.c
@@ -65,6 +65,7 @@ struct track_info *track_info_new(const char *filename)
 void track_info_set_comments(struct track_info *ti, struct keyval *comments) {
 	long int r128_track_gain;
 	long int r128_album_gain;
+	long int output_gain;
 
 	ti->comments = comments;
 	ti->artist = keyvals_get_val(comments, "artist");
@@ -108,6 +109,10 @@ void track_info_set_comments(struct track_info *ti, struct keyval *comments) {
 
 	if (comments_get_signed_int(comments, "r128_album_gain", &r128_album_gain) != -1) {
 		ti->rg_album_gain = (r128_album_gain / 256.0) + 5;
+	}
+
+	if (comments_get_signed_int(comments, "output_gain", &output_gain) != -1) {
+		ti->output_gain = (output_gain / 256.0);
 	}
 
 	ti->collkey_artist = u_strcasecoll_key0(ti->artist);

--- a/track_info.c
+++ b/track_info.c
@@ -58,6 +58,7 @@ struct track_info *track_info_new(const char *filename)
 	ti->bpm = -1;
 	ti->codec = NULL;
 	ti->codec_profile = NULL;
+	ti->output_gain = 0;
 
 	return ti;
 }

--- a/track_info.h
+++ b/track_info.h
@@ -46,6 +46,7 @@ struct track_info {
 	double rg_track_peak;
 	double rg_album_gain;
 	double rg_album_peak;
+	double output_gain;
 	const char *artist;
 	const char *album;
 	const char *title;


### PR DESCRIPTION
This pull request incorporates the output gain value from opus files when deciding if the replaygain adjustment would go over the 1.0 peak limit. (Issue #1200)
I don't know if this is a good solution to this problem and would appreciate any feedback.