### PR TITLE
Introduce basu as an option for MPRIS control

### DIFF
--- a/configure
+++ b/configure
@@ -315,7 +315,9 @@ check_vorbis()
 
 check_libsystemd()
 {
-	pkg_config LIBSYSTEMD "libsystemd" || pkg_config LIBSYSTEMD "libelogind >= 239.3"
+	pkg_config LIBSYSTEMD "libsystemd" || pkg_config LIBSYSTEMD "libelogind >= 239.3" || {
+		pkg_config LIBSYSTEMD "basu" && CFLAGS="${CFLAGS} -DCONFIG_MPRIS_BASU"
+	}
 	return $?
 }
 

--- a/mpris.c
+++ b/mpris.c
@@ -15,7 +15,11 @@
  * along with this program; if not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef CONFIG_MPRIS_BASU
+#include <basu/sd-bus.h>
+#else
 #include <systemd/sd-bus.h>
+#endif
 
 #include "mpris.h"
 #include "ui_curses.h"


### PR DESCRIPTION
Should help FreeBSD users have media key support. Closes #1133.