### PR TITLE
Remove AV_CODEC_{CAP,FLAG}_TRUNCATED for FFmpeg 6 compatibility

### DIFF
--- a/ip/ffmpeg.c
+++ b/ip/ffmpeg.c
@@ -202,9 +202,6 @@ static int ffmpeg_open(struct input_plugin_data *ip_data)
 			break;
 		}
 
-		if (codec->capabilities & AV_CODEC_CAP_TRUNCATED)
-			cc->flags |= AV_CODEC_FLAG_TRUNCATED;
-
 		if (avcodec_open2(cc, codec, NULL) < 0) {
 			d_print("could not open codec: %d, %s\n", cc->codec_id, avcodec_get_name(cc->codec_id));
 			err = -IP_ERROR_UNSUPPORTED_FILE_TYPE;


### PR DESCRIPTION
Closes #1251