### PR TITLE
 Fixed function detection. check_function failed to compile due to clang -Wint-conversion warning became error.

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -495,7 +495,7 @@ check_function()
 	__func="$1"
 	shift
 	msg_checking "for function $__func"
-	if try_compile_link "char $__func(); int main(int argc, char *argv[]) { return $__func; }" "$@"
+	if try_compile_link "char $__func(); int main(int argc, char *argv[]) { return ((int*)(&$__func))[argc]; }" "$@"
 	then
 		msg_result yes
 		return 0


### PR DESCRIPTION
In recent clang version the -Wint-conversion warning became an error. So the function detection doesn't work anymore.
Compiling this code with clang
`char resizeterm(); int main(int argc, char *argv[]) { return resizeterm; }`
results in error:
`main.c:1:62: error: incompatible pointer to integer conversion returning 'char ()' from a function with result type 'int' [-Wint-conversion]`
