### PR TITLE
Implement option to ignore pasted text in normal mode

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -898,6 +898,10 @@ altformat_trackwin [`Format String`]
 
 	Note: if empty, *format_trackwin* is used instead.
 
+block_key_paste (true)
+	Prevent accidental input by only accepting pasted text in the command line.
+	Only works on terminals which support bracketed paste.
+
 buffer_seconds (10) [1-300]
 	Size of the player buffer in seconds.
 

--- a/options.c
+++ b/options.c
@@ -93,6 +93,7 @@ int stop_after_queue = 0;
 int tree_width_percent = 33;
 int tree_width_max = 0;
 int pause_on_output_change = 0;
+int block_key_paste = 1;
 
 int colors[NR_COLORS] = {
 	-1,
@@ -1318,6 +1319,21 @@ static void toggle_pause_on_output_change(void *data)
 	pause_on_output_change ^= 1;
 }
 
+static void get_block_key_paste(void *data, char *buf, size_t size)
+{
+	strscpy(buf, bool_names[block_key_paste], size);
+}
+
+static void set_block_key_paste(void *data, const char *buf)
+{
+	parse_bool(buf, &block_key_paste);
+}
+
+static void toggle_block_key_paste(void *data)
+{
+	block_key_paste ^= 1;
+}
+
 /* }}} */
 
 /* special callbacks (id set) {{{ */
@@ -1581,6 +1597,7 @@ static const struct {
 	DN(tree_width_max)
 	DT(pause_on_output_change)
 	DN(pl_env_vars)
+	DT(block_key_paste)
 	{ NULL, NULL, NULL, NULL, 0 }
 };
 

--- a/options.h
+++ b/options.h
@@ -163,6 +163,7 @@ extern int stop_after_queue;
 extern int tree_width_percent;
 extern int tree_width_max;
 extern int pause_on_output_change;
+extern int block_key_paste;
 
 extern const char * const aaa_mode_names[];
 extern const char * const view_names[NR_VIEWS + 1];


### PR DESCRIPTION
This uses bracketed paste, where supported (xterm, win10, iterm2, etc), to prevent pasted text from being interpreted as commands unless the new `block_key_paste` option is disabled.

closes #1270