### PR TITLE
Add %{albumtracks} format string

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -1328,6 +1328,7 @@ Special Keys:
 	%l  %{album}		@br
 	%D  %{discnumber}	@br
 	%n  %{tracknumber}	@br
+	%N  %{albumtracks}	@br
 	%X  %{play_count}	@br
 	%t  %{title}		@br
 	%g  %{genre}		@br

--- a/lib.h
+++ b/lib.h
@@ -63,6 +63,7 @@ struct album {
 	int date;
 	/* min date of the tracks added to this album */
 	int min_date;
+	int num_tracks;
 };
 
 struct artist {

--- a/track_info.c
+++ b/track_info.c
@@ -26,6 +26,7 @@
 #include "debug.h"
 #include "path.h"
 #include "ui_curses.h"
+#include "lib.h"
 
 #include <string.h>
 #include <stdatomic.h>
@@ -59,6 +60,7 @@ struct track_info *track_info_new(const char *filename)
 	ti->codec = NULL;
 	ti->codec_profile = NULL;
 	ti->output_gain = 0;
+	ti->lib_album = NULL;
 
 	return ti;
 }

--- a/track_info.h
+++ b/track_info.h
@@ -30,6 +30,7 @@ struct track_info {
 
 	// next track_info in the hash table (cache.c)
 	struct track_info *next;
+	struct album *lib_album;
 
 	time_t mtime;
 	int duration;

--- a/tree.c
+++ b/tree.c
@@ -555,6 +555,7 @@ static struct album *album_new(struct artist *artist, const char *name,
 	album->min_date = date;
 	rb_root_init(&album->track_root);
 	album->artist = artist;
+	album->num_tracks = 0;
 
 	return album;
 }
@@ -867,6 +868,9 @@ static void album_add_track(struct album *album, struct tree_track *track)
 
 	rb_link_node(&track->tree_node, parent, new);
 	rb_insert_color(&track->tree_node, &album->track_root);
+
+	album->num_tracks++;
+	tree_track_info(track)->lib_album = album;
 }
 
 const char *tree_artist_name(const struct track_info* ti)
@@ -1177,6 +1181,9 @@ static void remove_track(struct tree_track *track)
 		window_row_vanishes(lib_track_win, (struct iter *)&iter);
 	}
 	rb_erase(&track->tree_node, &track->album->track_root);
+
+	track->album->num_tracks--;
+	tree_track_info(track)->lib_album = NULL;
 }
 
 void tree_remove(struct tree_track *track,

--- a/ui_curses.c
+++ b/ui_curses.c
@@ -258,6 +258,7 @@ enum {
 	TF_ALBUM,
 	TF_DISC,
 	TF_TRACK,
+	TF_ALBUMTRACKS,
 	TF_TITLE,
 	TF_PLAY_COUNT,
 	TF_YEAR,
@@ -316,6 +317,7 @@ static struct format_option track_fopts[NR_TFS + 1] = {
 	DEF_FO_STR('l', "album", 0),
 	DEF_FO_INT('D', "discnumber", 1),
 	DEF_FO_INT('n', "tracknumber", 1),
+	DEF_FO_INT('N', "albumtracks", 1),
 	DEF_FO_STR('t', "title", 0),
 	DEF_FO_INT('X', "play_count", 0),
 	DEF_FO_INT('y', "date", 1),
@@ -534,6 +536,8 @@ static void fill_track_fopts_track_info(struct track_info *info)
 	fopt_set_int(&track_fopts[TF_PLAY_COUNT], info->play_count, 0);
 	fopt_set_int(&track_fopts[TF_DISC], info->discnumber, info->discnumber == -1);
 	fopt_set_int(&track_fopts[TF_TRACK], info->tracknumber, info->tracknumber == -1);
+	fopt_set_int(&track_fopts[TF_ALBUMTRACKS], (info->lib_album ?
+				info->lib_album->num_tracks : 0), info->lib_album == NULL);
 	fopt_set_str(&track_fopts[TF_TITLE], info->title);
 	fopt_set_int(&track_fopts[TF_YEAR], info->date / 10000, info->date <= 0);
 	fopt_set_str(&track_fopts[TF_GENRE], info->genre);
@@ -589,6 +593,7 @@ static void fill_track_fopts_album(struct album *album)
 {
 	fopt_set_int(&track_fopts[TF_YEAR], album->min_date / 10000, album->min_date <= 0);
 	fopt_set_int(&track_fopts[TF_MAX_YEAR], album->date / 10000, album->date <= 0);
+	fopt_set_int(&track_fopts[TF_ALBUMTRACKS], album->num_tracks, album->num_tracks == 0);
 	fopt_set_str(&track_fopts[TF_ALBUMARTIST], album->artist->name);
 	fopt_set_str(&track_fopts[TF_ARTIST], album->artist->name);
 	fopt_set_str(&track_fopts[TF_ALBUM], album->name);


### PR DESCRIPTION
Total (counted) number of tracks in album. Also works as %N.

Closes #850.

For the example in that ticket, it would be `:set format_current= %a - %l%! - %n%{?N? (of %N)} - %t%= %y `.