### PR TITLE
Flag to prevent cycling with left-view / right-view

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -543,11 +543,18 @@ player-stop (*v*)
 prev-view
 	Goes to the previously used view.
 
-left-view
+left-view [-n]
 	Goes to the to view to the left of current one (e.g. view 4 -> view 3)
 
-right-view
+	@li -n
+	no cycle back to end when reaching the first view
+
+right-view [-n]
 	Goes to view to the right of current one (e.g. view 3 -> view 4).
+
+	@li -n
+	no cycle back to start when reaching the last view
+
 
 push [text]
 	Enters command mode with the command line pre-set to text. Example:

--- a/command_mode.c
+++ b/command_mode.c
@@ -1270,8 +1270,12 @@ static void cmd_prev_view(char *arg)
 
 static void cmd_left_view(char *arg)
 {
+	int flag = parse_flags((const char **)&arg, "n");
+
 	if (cur_view == TREE_VIEW) {
-		set_view(HELP_VIEW);
+		if (flag != 'n') {
+			set_view(HELP_VIEW);
+		}
 	} else {
 		set_view(cur_view - 1);
 	}
@@ -1279,8 +1283,12 @@ static void cmd_left_view(char *arg)
 
 static void cmd_right_view(char *arg)
 {
+	int flag = parse_flags((const char **)&arg, "n");
+
 	if (cur_view == HELP_VIEW) {
-		set_view(TREE_VIEW);
+		if (flag != 'n') {
+			set_view(TREE_VIEW);
+		}
 	} else {
 		set_view(cur_view + 1);
 	}
@@ -2622,8 +2630,8 @@ struct command commands[] = {
 	{ "player-prev-album",     cmd_p_prev_album,     0, 0,  NULL,                 0, 0          },
 	{ "player-stop",           cmd_p_stop,           0, 0,  NULL,                 0, 0          },
 	{ "prev-view",             cmd_prev_view,        0, 0,  NULL,                 0, 0          },
-	{ "left-view",             cmd_left_view,        0, 0,  NULL,                 0, 0          },
-	{ "right-view",            cmd_right_view,       0, 0,  NULL,                 0, 0          },
+	{ "left-view",             cmd_left_view,        0, 1,  NULL,                 0, 0          },
+	{ "right-view",            cmd_right_view,       0, 1,  NULL,                 0, 0          },
 	{ "pl-create",             cmd_pl_create,        1, -1, NULL,                 0, 0          },
 	{ "pl-export",             cmd_pl_export,        1, -1, NULL,                 0, 0          },
 	{ "pl-import",             cmd_pl_import,        0, -1, NULL,                 0, 0          },

--- a/data/rc
+++ b/data/rc
@@ -60,8 +60,8 @@ bind common 5 view browser
 bind common 6 view filters
 bind common 7 view settings
 
-bind common mouse_scroll_up_title left-view
-bind common mouse_scroll_down_title right-view
+bind common mouse_scroll_up_title left-view -n
+bind common mouse_scroll_down_title right-view -n
 
 bind common tab win-next
 


### PR DESCRIPTION
Added to the default mouse scroll binds, which is quite intuitive and seems to be how web browsers like to handle it. (For reference they do allow cycling when activated by keyboard shortcut, although we don't have any default keyboard binds for left-view / right-view.)

Closes #1241.