### PR TITLE
Add option to sort albums by name in tree view

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -1089,6 +1089,9 @@ smart_artist_sort (true)
 	names, preventing artists starting with "The" from clumping together.
 	Real `artistsort` tags override this option, if present.
 
+sort_albums_by_name (false)
+	In tree view (1), albums will be sorted by name rather than date.
+
 id3_default_charset (ISO-8859-1)
 	Default character set to use for ID3v1 and broken ID3v2 tags.
 

--- a/options.c
+++ b/options.c
@@ -76,6 +76,7 @@ int shuffle = 0;
 int follow = 0;
 int display_artist_sort_name;
 int smart_artist_sort = 1;
+int sort_albums_by_name = 0;
 int scroll_offset = 2;
 int rewind_offset = 5;
 int skip_track_info = 0;
@@ -753,6 +754,23 @@ static void set_smart_artist_sort(void *data, const char *buf)
 static void toggle_smart_artist_sort(void *data)
 {
 	smart_artist_sort ^= 1;
+	lib_sort_artists();
+}
+
+static void get_sort_albums_by_name(void *data, char *buf, size_t size)
+{
+	strscpy(buf, bool_names[sort_albums_by_name], size);
+}
+
+static void set_sort_albums_by_name(void *data, const char *buf)
+{
+	parse_bool(buf, &sort_albums_by_name);
+	lib_sort_artists();
+}
+
+static void toggle_sort_albums_by_name(void *data)
+{
+	sort_albums_by_name ^= 1;
 	lib_sort_artists();
 }
 
@@ -1554,6 +1572,7 @@ static const struct {
 	DT(continue)
 	DT(continue_album)
 	DT(smart_artist_sort)
+	DT(sort_albums_by_name)
 	DN(id3_default_charset)
 	DN(icecast_default_charset)
 	DN(lib_sort)

--- a/options.h
+++ b/options.h
@@ -151,6 +151,7 @@ extern int shuffle;
 extern int follow;
 extern int display_artist_sort_name;
 extern int smart_artist_sort;
+extern int sort_albums_by_name;
 extern int scroll_offset;
 extern int rewind_offset;
 extern int skip_track_info;

--- a/tree.c
+++ b/tree.c
@@ -828,14 +828,11 @@ static void add_album(struct album *album)
 	struct rb_node **new = &(album->artist->album_root.rb_node), *parent = NULL;
 	struct album *found;
 
-	/*
-	 * Sort regular albums by date, but sort compilations
-	 * alphabetically.
-	 */
-	found = do_find_album(album,
-			      album->artist->is_compilation ? special_album_cmp
-							    : special_album_cmp_date,
-			      &new, &parent);
+	if (sort_albums_by_name || album->artist->is_compilation)
+		found = do_find_album(album, special_album_cmp, &new, &parent);
+	else
+		found = do_find_album(album, special_album_cmp_date, &new, &parent);
+
 	if (!found) {
 		rb_link_node(&album->tree_node, parent, new);
 		rb_insert_color(&album->tree_node, &album->artist->album_root);
@@ -1240,6 +1237,8 @@ void tree_sort_artists(void (*add_album_cb)(struct album *),
 			struct rb_node *t_node, *t_tmp;
 			struct album *album = to_album(l_node);
 
+			remove_album(album);
+			add_album(album);
 			rb_for_each_safe(t_node, t_tmp, &album->track_root) {
 				struct tree_track *track = to_tree_track(t_node);
 


### PR DESCRIPTION
By default they are still sorted by date, which is the current behavior.

I considered to also add an equivalent of smart_artist_sort, to strip "The" from album names when sorting. It could be nice to add for consistency, but I find it's not that useful when the list of albums under a given artist tends to be quite small anyway.

Closes #909.