### PR TITLE
Fix ignore_duplicates missing filtered tracks

### DIFF
--- a/lib.c
+++ b/lib.c
@@ -631,7 +631,7 @@ static void hash_add_to_views(void)
 		while (e) {
 			struct track_info *ti = e->ti;
 
-			if (!is_filtered(ti))
+			if (!is_filtered(ti) && !(ignore_duplicates && track_exists(ti)))
 				views_add_track(ti);
 			e = e->next;
 		}


### PR DESCRIPTION
Really just checking for duplicates again when unfiltering. A bit messy but it does the job.

The "entryp" naming is consistent with `hash_remove()` etc.

Relates to #423.