### PR TITLE
Reduce R128 gain precision to 2 places of decimal

### DIFF
--- a/track_info.c
+++ b/track_info.c
@@ -106,11 +106,13 @@ void track_info_set_comments(struct track_info *ti, struct keyval *comments) {
 	ti->rg_album_peak = comments_get_double(comments, "replaygain_album_peak");
 
 	if (comments_get_signed_int(comments, "r128_track_gain", &r128_track_gain) != -1) {
-		ti->rg_track_gain = (r128_track_gain / 256.0) + 5;
+		double rg = (r128_track_gain / 256.0) + 5;
+		ti->rg_track_gain = round(rg * 100) / 100.0;
 	}
 
 	if (comments_get_signed_int(comments, "r128_album_gain", &r128_album_gain) != -1) {
-		ti->rg_album_gain = (r128_album_gain / 256.0) + 5;
+		double rg = (r128_album_gain / 256.0) + 5;
+		ti->rg_album_gain = round(rg * 100) / 100.0;
 	}
 
 	if (comments_get_signed_int(comments, "output_gain", &output_gain) != -1) {


### PR DESCRIPTION
The Q7.8 encoding is only capable of accurately storing 2 decimal places. It's misleading (and ugly) to present it as otherwise when printed.