### PR TITLE
Add %{totaldiscs} to available format string

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -1327,6 +1327,7 @@ Special Keys:
 	%A  %{albumartist}	@br
 	%l  %{album}		@br
 	%D  %{discnumber}	@br
+	%T  %{totaldiscs}	@br
 	%n  %{tracknumber}	@br
 	%X  %{play_count}	@br
 	%t  %{title}		@br

--- a/comment.c
+++ b/comment.c
@@ -195,7 +195,7 @@ int comments_get_date(const struct keyval *comments, const char *key)
 }
 
 static const char *interesting[] = {
-	"artist", "album", "title", "tracknumber", "discnumber", "genre",
+	"artist", "album", "title", "tracknumber", "discnumber", "totaldiscs", "genre",
 	"date", "compilation", "partofacompilation", "albumartist", "artistsort", "albumartistsort",
 	"albumsort",
 	"originaldate",
@@ -221,6 +221,7 @@ static struct {
 	{ "album_artist", "albumartist" },
 	{ "album artist", "albumartist" },
 	{ "disc", "discnumber" },
+	{ "dicstotal", "totaldiscs" },
 	{ "tempo", "bpm" },
 	{ "track", "tracknumber" },
 	{ "WM/Year", "date" },

--- a/track_info.c
+++ b/track_info.c
@@ -74,6 +74,7 @@ void track_info_set_comments(struct track_info *ti, struct keyval *comments) {
 	ti->title = keyvals_get_val(comments, "title");
 	ti->tracknumber = comments_get_int(comments, "tracknumber");
 	ti->discnumber = comments_get_int(comments, "discnumber");
+	ti->totaldiscs = comments_get_int(comments, "totaldiscs");
 	ti->date = comments_get_date(comments, "date");
 	ti->originaldate = comments_get_date(comments, "originaldate");
 	ti->genre = keyvals_get_val(comments, "genre");
@@ -246,6 +247,7 @@ int track_info_cmp(const struct track_info *a, const struct track_info *b, const
 		switch (key) {
 		case SORT_TRACKNUMBER:
 		case SORT_DISCNUMBER:
+		case SORT_TOTALDISCS:
 		case SORT_DATE:
 		case SORT_ORIGINALDATE:
 		case SORT_PLAY_COUNT:
@@ -291,6 +293,7 @@ static const struct {
 	{ "play_count",		SORT_PLAY_COUNT		},
 	{ "tracknumber",	SORT_TRACKNUMBER	},
 	{ "discnumber",		SORT_DISCNUMBER		},
+	{ "totaldiscs",		SORT_TOTALDISCS		},
 	{ "date",		SORT_DATE		},
 	{ "originaldate",	SORT_ORIGINALDATE	},
 	{ "genre",		SORT_GENRE		},
@@ -313,6 +316,7 @@ static const struct {
 	{ "-play_count", 	REV_SORT_PLAY_COUNT	},
 	{ "-tracknumber",	REV_SORT_TRACKNUMBER	},
 	{ "-discnumber",	REV_SORT_DISCNUMBER	},
+	{ "-totaldiscs",	REV_SORT_TOTALDISCS	},
 	{ "-date",		REV_SORT_DATE		},
 	{ "-originaldate",	REV_SORT_ORIGINALDATE	},
 	{ "-genre",		REV_SORT_GENRE		},

--- a/track_info.h
+++ b/track_info.h
@@ -40,6 +40,7 @@ struct track_info {
 
 	int tracknumber;
 	int discnumber;
+	int totaldiscs;
 	int date;
 	int originaldate;
 	double rg_track_gain;
@@ -78,6 +79,7 @@ typedef size_t sort_key_t;
 #define SORT_TITLE         	offsetof(struct track_info, collkey_title)
 #define SORT_TRACKNUMBER   	offsetof(struct track_info, tracknumber)
 #define SORT_DISCNUMBER    	offsetof(struct track_info, discnumber)
+#define SORT_TOTALDISCS    	offsetof(struct track_info, totaldiscs)
 #define SORT_DATE          	offsetof(struct track_info, date)
 #define SORT_ORIGINALDATE  	offsetof(struct track_info, originaldate)
 #define SORT_RG_TRACK_GAIN 	offsetof(struct track_info, rg_track_gain)
@@ -102,6 +104,7 @@ typedef size_t sort_key_t;
 #define REV_SORT_PLAY_COUNT   	(REV_SORT__START + offsetof(struct track_info, play_count))
 #define REV_SORT_TRACKNUMBER    (REV_SORT__START + offsetof(struct track_info, tracknumber))
 #define REV_SORT_DISCNUMBER     (REV_SORT__START + offsetof(struct track_info, discnumber))
+#define REV_SORT_TOTALDISCS     (REV_SORT__START + offsetof(struct track_info, totaldiscs))
 #define REV_SORT_DATE           (REV_SORT__START + offsetof(struct track_info, date))
 #define REV_SORT_ORIGINALDATE   (REV_SORT__START + offsetof(struct track_info, originaldate))
 #define REV_SORT_RG_TRACK_GAIN  (REV_SORT__START + offsetof(struct track_info, rg_track_gain))

--- a/ui_curses.c
+++ b/ui_curses.c
@@ -257,6 +257,7 @@ enum {
 	TF_ARTIST,
 	TF_ALBUM,
 	TF_DISC,
+	TF_TOTAL_DISCS,
 	TF_TRACK,
 	TF_TITLE,
 	TF_PLAY_COUNT,
@@ -315,6 +316,7 @@ static struct format_option track_fopts[NR_TFS + 1] = {
 	DEF_FO_STR('a', "artist", 0),
 	DEF_FO_STR('l', "album", 0),
 	DEF_FO_INT('D', "discnumber", 1),
+	DEF_FO_INT('T', "totaldiscs", 1),
 	DEF_FO_INT('n', "tracknumber", 1),
 	DEF_FO_STR('t', "title", 0),
 	DEF_FO_INT('X', "play_count", 0),
@@ -533,6 +535,7 @@ static void fill_track_fopts_track_info(struct track_info *info)
 	fopt_set_str(&track_fopts[TF_ALBUM], info->album);
 	fopt_set_int(&track_fopts[TF_PLAY_COUNT], info->play_count, 0);
 	fopt_set_int(&track_fopts[TF_DISC], info->discnumber, info->discnumber == -1);
+	fopt_set_int(&track_fopts[TF_TOTAL_DISCS], info->totaldiscs, info->totaldiscs == -1);
 	fopt_set_int(&track_fopts[TF_TRACK], info->tracknumber, info->tracknumber == -1);
 	fopt_set_str(&track_fopts[TF_TITLE], info->title);
 	fopt_set_int(&track_fopts[TF_YEAR], info->date / 10000, info->date <= 0);


### PR DESCRIPTION
Allows displaying the number of discs of an album. Can also be used as a condition. Shorthand is `%T`.

I added it because I wanted to display the disc number only if the total number of discs is greater than one.