### PR TITLE
Add support to XDG_CACHE_HOME

### DIFF
--- a/cache.c
+++ b/cache.c
@@ -284,7 +284,7 @@ int cache_init(void)
 	/* assumed version */
 	cache_header[3] = CACHE_VERSION;
 
-	cache_filename = xstrjoin(cmus_config_dir, "/cache");
+	cache_filename = xstrjoin(cmus_cache_dir, "/cache");
 	return read_cache();
 }
 
@@ -391,7 +391,7 @@ int cache_close(void)
 	int i, fd, rc;
 	char *tmp;
 
-	tmp = xstrjoin(cmus_config_dir, "/cache.tmp");
+	tmp = xstrjoin(cmus_cache_dir, "/cache.tmp");
 	fd = open(tmp, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (fd < 0) {
 		free(tmp);

--- a/misc.c
+++ b/misc.c
@@ -40,6 +40,7 @@ const char *cmus_playlist_dir = NULL;
 const char *cmus_socket_path = NULL;
 const char *cmus_data_dir = NULL;
 const char *cmus_lib_dir = NULL;
+const char *cmus_cache_dir = NULL;
 const char *home_dir = NULL;
 
 char **get_words(const char *text)
@@ -261,6 +262,16 @@ int misc_init(void)
 			cmus_socket_path = xstrjoin(xdg_runtime_dir, "/cmus-socket");
 		}
 	}
+
+	char *xdg_cache_dir = get_non_empty_env("XDG_CACHE_HOME");
+	if (xdg_cache_dir == NULL)
+		xdg_cache_dir = xstrjoin(home_dir, "/.cache");
+
+	cmus_cache_dir = get_non_empty_env("CMUS_CACHE_DIR");
+	if (!cmus_cache_dir)
+		cmus_cache_dir = xstrjoin(xdg_cache_dir, "/cmus");
+	make_dir(cmus_cache_dir);
+	free(xdg_cache_dir);
 
 	cmus_lib_dir = getenv("CMUS_LIB_DIR");
 	if (!cmus_lib_dir)

--- a/misc.h
+++ b/misc.h
@@ -26,6 +26,7 @@ extern const char *cmus_playlist_dir;
 extern const char *cmus_socket_path;
 extern const char *cmus_data_dir;
 extern const char *cmus_lib_dir;
+extern const char *cmus_cache_dir;
 extern const char *home_dir;
 
 char **get_words(const char *text);


### PR DESCRIPTION
Now, if the user has XDG_CACHE_HOME set, cmus will use $XDG_CACHE_HOME/cmus/ folder to place cache file. If, however, the variable is not set, cmus will use $HOME/.cache/cmus/ as the folder to place cache file.

As mentioned by #1283, xdg specs has been support for a while, yet cmus was saving cache files on $HOME/.config/cmus folder.