### PR TITLE
Add commands for external playlist management

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -516,6 +516,9 @@ pl-import [filename]
 pl-rename <name>
 	Renames the selected playlist.
 
+pl-delete <name>
+	Deletes the playlist with the given name.
+
 pl-delete-all
 	Deletes all playlists.
 

--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -516,6 +516,9 @@ pl-import [filename]
 pl-rename <name>
 	Renames the selected playlist.
 
+pl-delete-all
+	Deletes all playlists.
+
 player-next (*b*)
 	Skips to the next track.
 

--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -505,6 +505,12 @@ mute
 pl-create <name>
 	Creates a new playlist.
 
+pl-delete [-a] <name>
+	Deletes the playlist with the given name.
+
+	-a
+		Deletes all playlists
+
 pl-export <filename>
 	Exports the currently selected playlist. The file will be overwritten if
 	it exists.
@@ -515,12 +521,6 @@ pl-import [filename]
 
 pl-rename <name>
 	Renames the selected playlist.
-
-pl-delete [-a] <name>
-	Deletes the playlist with the given name.
-
-	-a
-		Deletes all playlists
 
 player-next (*b*)
 	Skips to the next track.

--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -516,11 +516,11 @@ pl-import [filename]
 pl-rename <name>
 	Renames the selected playlist.
 
-pl-delete <name>
+pl-delete [-a] <name>
 	Deletes the playlist with the given name.
 
-pl-delete-all
-	Deletes all playlists.
+	-a
+		Deletes all playlists
 
 player-next (*b*)
 	Skips to the next track.

--- a/command_mode.c
+++ b/command_mode.c
@@ -1354,6 +1354,11 @@ static void cmd_pl_rename(char *arg)
 		info_msg(":pl-rename only works in view 3");
 }
 
+static void cmd_pl_delete_all(char *arg)
+{
+	pl_delete_all();
+}
+
 static void cmd_version(char *arg)
 {
 	info_msg(VERSION);
@@ -2645,6 +2650,7 @@ struct command commands[] = {
 	{ "pl-export",             cmd_pl_export,        1, -1, NULL,                 0, 0          },
 	{ "pl-import",             cmd_pl_import,        0, -1, NULL,                 0, 0          },
 	{ "pl-rename",             cmd_pl_rename,        1, -1, NULL,                 0, 0          },
+	{ "pl-delete-all",         cmd_pl_delete_all,    0, 0,  NULL,                 0, 0          },
 	{ "push",                  cmd_push,             0, -1, expand_commands,      0, 0          },
 	{ "pwd",                   cmd_pwd,              0, 0,  NULL,                 0, 0          },
 	{ "raise-vte",             cmd_raise_vte,        0, 0,  NULL,                 0, 0          },

--- a/command_mode.c
+++ b/command_mode.c
@@ -1354,6 +1354,11 @@ static void cmd_pl_rename(char *arg)
 		info_msg(":pl-rename only works in view 3");
 }
 
+static void cmd_pl_delete(char *arg)
+{
+	pl_delete_by_name(arg);
+}
+
 static void cmd_pl_delete_all(char *arg)
 {
 	pl_delete_all();
@@ -2650,6 +2655,7 @@ struct command commands[] = {
 	{ "pl-export",             cmd_pl_export,        1, -1, NULL,                 0, 0          },
 	{ "pl-import",             cmd_pl_import,        0, -1, NULL,                 0, 0          },
 	{ "pl-rename",             cmd_pl_rename,        1, -1, NULL,                 0, 0          },
+	{ "pl-delete",             cmd_pl_delete,        1, 1,  NULL,                 0, 0          },
 	{ "pl-delete-all",         cmd_pl_delete_all,    0, 0,  NULL,                 0, 0          },
 	{ "push",                  cmd_push,             0, -1, expand_commands,      0, 0          },
 	{ "pwd",                   cmd_pwd,              0, 0,  NULL,                 0, 0          },

--- a/command_mode.c
+++ b/command_mode.c
@@ -1356,12 +1356,11 @@ static void cmd_pl_rename(char *arg)
 
 static void cmd_pl_delete(char *arg)
 {
-	pl_delete_by_name(arg);
-}
-
-static void cmd_pl_delete_all(char *arg)
-{
-	pl_delete_all();
+	int flag = parse_flags((const char **)&arg, "a");
+	if (flag == 'a')
+		pl_delete_all();
+	else
+		pl_delete_by_name(arg);
 }
 
 static void cmd_version(char *arg)
@@ -2656,7 +2655,6 @@ struct command commands[] = {
 	{ "pl-import",             cmd_pl_import,        0, -1, NULL,                 0, 0          },
 	{ "pl-rename",             cmd_pl_rename,        1, -1, NULL,                 0, 0          },
 	{ "pl-delete",             cmd_pl_delete,        1, 1,  NULL,                 0, 0          },
-	{ "pl-delete-all",         cmd_pl_delete_all,    0, 0,  NULL,                 0, 0          },
 	{ "push",                  cmd_push,             0, -1, expand_commands,      0, 0          },
 	{ "pwd",                   cmd_pwd,              0, 0,  NULL,                 0, 0          },
 	{ "raise-vte",             cmd_raise_vte,        0, 0,  NULL,                 0, 0          },

--- a/pl.c
+++ b/pl.c
@@ -476,15 +476,12 @@ void pl_delete_all(void)
 {
 	struct playlist *pl;
 	struct playlist *temp;
-	struct playlist *last = NULL;
 	list_for_each_entry_safe(pl, temp, &pl_head, node) {
-		if (list_len(&pl_head) == 1) {
-			last = pl;
+		if (list_len(&pl_head) == 1)
 			break;
-		}
 		pl_delete(pl);
 	}
-	pl_delete(last);
+	pl_delete(pl);
 }
 
 static void pl_mark_selected_pl(void)

--- a/pl.c
+++ b/pl.c
@@ -465,6 +465,22 @@ static void pl_delete_selected_pl(void)
 	pl_delete(pl_visible);
 }
 
+void pl_delete_all(void)
+{
+	struct playlist *pl;
+	struct playlist *temp;
+	struct playlist *last = NULL;
+	list_for_each_entry_safe(pl, temp, &pl_head, node) {
+		if (list_len(&pl_head) == 1) {
+			last = pl;
+			break;
+		}
+		pl_delete(pl);
+	}
+	pl_create_default();
+	pl_delete(last);
+}
+
 static void pl_mark_selected_pl(void)
 {
 	pl_marked = pl_visible;

--- a/pl.c
+++ b/pl.c
@@ -422,7 +422,7 @@ static void pl_save_all(void)
 static void pl_delete(struct playlist *pl)
 {
 	if (list_len(&pl_head) == 1)
-		return;
+		pl_create_default();
 
 	struct iter iter;
 	pl_to_iter(pl, &iter);
@@ -454,11 +454,6 @@ static void pl_delete(struct playlist *pl)
 
 static void pl_delete_selected_pl(void)
 {
-	if (list_len(&pl_head) == 1) {
-		error_msg("cannot delete the last playlist");
-		return;
-	}
-
 	if (yes_no_query("Delete selected playlist? [y/N]") != UI_QUERY_ANSWER_YES)
 		return;
 
@@ -477,7 +472,6 @@ void pl_delete_all(void)
 		}
 		pl_delete(pl);
 	}
-	pl_create_default();
 	pl_delete(last);
 }
 

--- a/pl.c
+++ b/pl.c
@@ -838,6 +838,17 @@ void pl_rand(void)
 		editable_rand(&pl_visible->editable);
 }
 
+void pl_delete_by_name(char *name)
+{
+	struct playlist *pl;
+	list_for_each_entry(pl, &pl_head, node) {
+		if (strcmp(pl->name, name) == 0)
+			break;
+	}
+	pl_delete(pl);
+}
+
+
 void pl_win_mv_after(void)
 {
 	if (pl_cursor_in_track_window)

--- a/pl.c
+++ b/pl.c
@@ -419,17 +419,10 @@ static void pl_save_all(void)
 		pl_save_one(pl);
 }
 
-static void pl_delete_selected_pl(void)
+static void pl_delete(struct playlist *pl)
 {
-	if (list_len(&pl_head) == 1) {
-		error_msg("cannot delete the last playlist");
+	if (list_len(&pl_head) == 1)
 		return;
-	}
-
-	if (yes_no_query("Delete selected playlist? [y/N]") != UI_QUERY_ANSWER_YES)
-		return;
-
-	struct playlist *pl = pl_visible;
 
 	struct iter iter;
 	pl_to_iter(pl, &iter);
@@ -457,6 +450,19 @@ static void pl_delete_selected_pl(void)
 	pdd->cb = pl_free;
 	pdd->pl = pl;
 	job_schedule_pl_delete(pdd);
+}
+
+static void pl_delete_selected_pl(void)
+{
+	if (list_len(&pl_head) == 1) {
+		error_msg("cannot delete the last playlist");
+		return;
+	}
+
+	if (yes_no_query("Delete selected playlist? [y/N]") != UI_QUERY_ANSWER_YES)
+		return;
+
+	pl_delete(pl_visible);
 }
 
 static void pl_mark_selected_pl(void)

--- a/pl.c
+++ b/pl.c
@@ -460,6 +460,18 @@ static void pl_delete_selected_pl(void)
 	pl_delete(pl_visible);
 }
 
+void pl_delete_by_name(char *name)
+{
+	struct playlist *pl;
+	list_for_each_entry(pl, &pl_head, node) {
+		if (strcmp(pl->name, name) == 0) {
+			pl_delete(pl);
+			return;
+		}
+	}
+	error_msg("couldn't find a playlist named '%s' to delete", name);
+}
+
 void pl_delete_all(void)
 {
 	struct playlist *pl;
@@ -831,17 +843,6 @@ void pl_rand(void)
 	pl_tw_only("rand")
 		editable_rand(&pl_visible->editable);
 }
-
-void pl_delete_by_name(char *name)
-{
-	struct playlist *pl;
-	list_for_each_entry(pl, &pl_head, node) {
-		if (strcmp(pl->name, name) == 0)
-			break;
-	}
-	pl_delete(pl);
-}
-
 
 void pl_win_mv_after(void)
 {

--- a/pl.h
+++ b/pl.h
@@ -89,6 +89,7 @@ void pl_mark(char *arg);
 void pl_unmark(void);
 void pl_rand(void);
 void pl_delete_all(void);
+void pl_delete_by_name(char *arg);
 void pl_win_mv_after(void);
 void pl_win_mv_before(void);
 void pl_win_remove(void);

--- a/pl.h
+++ b/pl.h
@@ -88,6 +88,7 @@ void pl_invert_marks(void);
 void pl_mark(char *arg);
 void pl_unmark(void);
 void pl_rand(void);
+void pl_delete_all(void);
 void pl_win_mv_after(void);
 void pl_win_mv_before(void);
 void pl_win_remove(void);


### PR DESCRIPTION
This PR implements the commands "pl-delete" and "pl-delete-all" that remove playlists for use with cmus-remote.

Other playlist management functionality needs further design discussion but these commands should be sufficient if all playlists are managed externally (which is my use case).

Partially addresses #1066