### PR TITLE
Allow cue plugin to parse cue sheet with multiple files.

### DIFF
--- a/cue.h
+++ b/cue.h
@@ -32,14 +32,13 @@ struct cue_meta {
 };
 
 struct cue_track {
+	char *file;
 	double offset;
 	double length;
 	struct cue_meta meta;
 };
 
 struct cue_sheet {
-	char *file;
-
 	struct cue_track *tracks;
 	size_t num_tracks;
 	size_t track_base;

--- a/ip/cue.c
+++ b/ip/cue.c
@@ -110,7 +110,7 @@ static int cue_open(struct input_plugin_data *ip_data)
 		goto cue_read_failed;
 	}
 
-	child_filename = _make_absolute_path(priv->cue_filename, cd->file);
+	child_filename = _make_absolute_path(priv->cue_filename, t->file);
 	priv->child = ip_new(child_filename);
 	free(child_filename);
 


### PR DESCRIPTION
The cue plugin will fail when parsing multiple FILE entry because of the postion check and fixed file entry.

Make the parser more robust so it can paser the cue sheet with multiple files like this

```
PERFORMER "XXX"
TITLE "XXXXX"
FILE "XXXX1.wav" WAVE
  TRACK 01 AUDIO
    TITLE "XXX"
    PERFORMER "XXX"
    INDEX 01 0:00:00
  TRACK 02 AUDIO
    TITLE "XXX"
    PERFORMER "XXX"
    INDEX 01 4:34:44
FILE "XXXX2.wav" WAVE
  TRACK 03 AUDIO
    TITLE "XXX"
    PERFORMER "XXX"
    INDEX 01 0:00:00
```