### PR TITLE
Fix library detection on Apple Silicon

### DIFF
--- a/configure
+++ b/configure
@@ -450,7 +450,7 @@ check_roar()
 
 check_mp4()
 {
-	pkg_config MP4 "mp4v2 faad2" "" "-lmp4v2 -lfaad -lm"
+	pkg_config MP4 "mp4v2 faad2" "" "-lmp4v2 -lfaad -lm" || return $?
 	USE_MPEG4IP=0
 	if ! check_header mp4v2/mp4v2.h $MP4_CFLAGS
 	then
@@ -464,7 +464,7 @@ check_mp4()
 
 check_aac()
 {
-	pkg_config AAC faad2 "" "-lfaad -lm"
+	pkg_config AAC faad2 "" "-lfaad -lm" || return $?
 	check_header neaacdec.h $AAC_CFLAGS
 	return $?
 }

--- a/configure
+++ b/configure
@@ -450,6 +450,8 @@ check_roar()
 
 check_mp4()
 {
+	pkg_config MP4 "mp4v2 faad2" && return
+	# if pkg_config didn't find them, check header/lib search paths
 	USE_MPEG4IP=1
 	if check_header mp4v2/mp4v2.h
 	then
@@ -464,7 +466,11 @@ check_mp4()
 
 check_aac()
 {
-  pkg_config AAC faad2 || return $?
+	pkg_config AAC faad2 && return
+	# if pkg_config didn't find it, check header/lib search paths
+	check_header neaacdec.h &&
+	check_library AAC "" "-lfaad -lm"
+	return $?
 }
 
 check_ffmpeg()

--- a/configure
+++ b/configure
@@ -464,9 +464,7 @@ check_mp4()
 
 check_aac()
 {
-	check_header neaacdec.h &&
-	check_library AAC "" "-lfaad -lm"
-	return $?
+  pkg_config AAC faad2 || return $?
 }
 
 check_ffmpeg()

--- a/configure
+++ b/configure
@@ -450,26 +450,22 @@ check_roar()
 
 check_mp4()
 {
-	pkg_config MP4 "mp4v2 faad2" && return
-	# if pkg_config didn't find them, check header/lib search paths
-	USE_MPEG4IP=1
-	if check_header mp4v2/mp4v2.h
+	pkg_config MP4 "mp4v2 faad2" "" "-lmp4v2 -lfaad -lm"
+	USE_MPEG4IP=0
+	if ! check_header mp4v2/mp4v2.h $MP4_CFLAGS
 	then
-		USE_MPEG4IP=0
-	else
-		check_header mp4.h || return $?
+		# couldn't find the v2 header, try falling back to mp4.h
+		USE_MPEG4IP=1
+		check_header mp4.h $MP4_CFLAGS || return $?
 	fi
-	check_header neaacdec.h &&
-	check_library MP4 "" "-lmp4v2 -lfaad -lm"
+	check_header neaacdec.h $MP4_CFLAGS
 	return $?
 }
 
 check_aac()
 {
-	pkg_config AAC faad2 && return
-	# if pkg_config didn't find it, check header/lib search paths
-	check_header neaacdec.h &&
-	check_library AAC "" "-lfaad -lm"
+	pkg_config AAC faad2 "" "-lfaad -lm"
+	check_header neaacdec.h $AAC_CFLAGS
 	return $?
 }
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -26,7 +26,7 @@ __cleanup()
 		echo "DEBUG_CONFIGURE=y, not removing temporary files"
 		ls .tmp-[0-9]*-*
 	else
-		rm -f .tmp-[0-9]*-*
+		rm -rf .tmp-[0-9]*-*
 	fi
 }
 


### PR DESCRIPTION
On Apple Silicon, Homebrew doesn't install ARM packages to the global header/library paths. This means that the common package dependencies `faad2` and `mp4v2` can no longer be detected by checking `/usr/local`, so `configure` fails to find them and disables AAC and MP4.

This is fixed by using `pkg-config` to check for those dependencies, since Homebrew's `pkg-config` search path accounts for the CPU architecture, and gives the correct results on both Intel and ARM.

I left the previous behavior in place as a fallback, for systems that have the libs installed globally without a working `pkg-config`.

Minor housekeeping: I also changed the temp file cleanup at the end to use `-r` with `rm`, since on macOS the configure script generates `.dSYM` directories from its temp file builds, and the script was printing errors every time it failed to delete them.