### PR TITLE
add play_queue total_time

### DIFF
--- a/play_queue.c
+++ b/play_queue.c
@@ -83,3 +83,8 @@ int play_queue_for_each(int (*cb)(void *data, struct track_info *ti),
 	}
 	return rc;
 }
+
+unsigned int play_queue_total_time(void)
+{
+	return pq_editable.total_time;
+}

--- a/play_queue.c
+++ b/play_queue.c
@@ -93,3 +93,8 @@ int queue_needs_redraw(void)
 {
 	return pq_editable.shared->win->changed;
 }
+
+void queue_post_update(void)
+{
+	pq_editable.shared->win->changed = 0;
+}

--- a/play_queue.c
+++ b/play_queue.c
@@ -88,3 +88,8 @@ unsigned int play_queue_total_time(void)
 {
 	return pq_editable.total_time;
 }
+
+int queue_needs_redraw(void)
+{
+	return pq_editable.shared->win->changed;
+}

--- a/play_queue.h
+++ b/play_queue.h
@@ -32,5 +32,6 @@ int play_queue_for_each(int (*cb)(void *data, struct track_info *ti),
 		void *data, void *opaque);
 unsigned int play_queue_total_time(void);
 int queue_needs_redraw(void);
+void queue_post_update(void);
 
 #endif

--- a/play_queue.h
+++ b/play_queue.h
@@ -31,5 +31,6 @@ struct track_info *play_queue_remove(void);
 int play_queue_for_each(int (*cb)(void *data, struct track_info *ti),
 		void *data, void *opaque);
 unsigned int play_queue_total_time(void);
+int queue_needs_redraw(void);
 
 #endif

--- a/play_queue.h
+++ b/play_queue.h
@@ -30,5 +30,6 @@ void play_queue_prepend(struct track_info *ti, void *opaque);
 struct track_info *play_queue_remove(void);
 int play_queue_for_each(int (*cb)(void *data, struct track_info *ti),
 		void *data, void *opaque);
+unsigned int play_queue_total_time(void);
 
 #endif

--- a/ui_curses.c
+++ b/ui_curses.c
@@ -641,8 +641,12 @@ const struct format_option *get_global_fopts(void)
 	int buffer_fill, vol, vol_left, vol_right;
 	int duration = -1;
 
-	fopt_set_time(&track_fopts[TF_TOTAL], play_library ? lib_editable.total_time :
-			pl_playing_total_time(), 0);
+	unsigned int total_time = pl_playing_total_time();
+	if (cmus_queue_active())
+		total_time = play_queue_total_time();
+	else if (play_library)
+		total_time = lib_editable.total_time;
+	fopt_set_time(&track_fopts[TF_TOTAL], total_time, 0);
 
 	fopt_set_str(&track_fopts[TF_FOLLOW], follow_strs[follow]);
 	fopt_set_str(&track_fopts[TF_REPEAT], repeat_strs[repeat]);

--- a/ui_curses.c
+++ b/ui_curses.c
@@ -2040,6 +2040,9 @@ static void update(void)
 			do_update_commandline();
 		post_update();
 	}
+
+	/* Reset changed flags */
+	queue_post_update();
 }
 
 static void handle_ch(uchar ch)

--- a/ui_curses.c
+++ b/ui_curses.c
@@ -2015,7 +2015,9 @@ static void update(void)
 	}
 
 	/* total time changed? */
-	if (play_library) {
+	if (cmus_queue_active()) {
+		needs_status_update += queue_needs_redraw();
+	} else if (play_library) {
 		needs_status_update += lib_editable.shared->win->changed;
 		lib_editable.shared->win->changed = 0;
 	} else {


### PR DESCRIPTION
The format option "total" will display the total time in the library or the current playing list, but if the queue is active it should instead display the total time of the queue.