### PR TITLE
Make PART / PARTNUMBER aliases for DISCNUMBER

### DIFF
--- a/comment.c
+++ b/comment.c
@@ -209,7 +209,7 @@ static const char *interesting[] = {
 	"comment",
 	"bpm",
 	"arranger", "composer", "conductor", "lyricist", "performer",
-	"remixer", "label", "publisher", "work", "opus", "partnumber", "part",
+	"remixer", "label", "publisher", "work", "opus",
 	"subtitle", "media",
 	NULL
 };
@@ -221,7 +221,9 @@ static struct {
 	{ "album_artist", "albumartist" },
 	{ "album artist", "albumartist" },
 	{ "disc", "discnumber" },
-	{ "dicstotal", "totaldiscs" },
+	{ "part", "discnumber" },
+	{ "partnumber", "discnumber" },
+	{ "disctotal", "totaldiscs" },
 	{ "tempo", "bpm" },
 	{ "track", "tracknumber" },
 	{ "WM/Year", "date" },

--- a/ui_curses.c
+++ b/ui_curses.c
@@ -562,8 +562,8 @@ static void fill_track_fopts_track_info(struct track_info *info)
 	fopt_set_str(&track_fopts[TF_PUBLISHER], keyvals_get_val(info->comments, "publisher"));
 	fopt_set_str(&track_fopts[TF_WORK], keyvals_get_val(info->comments, "work"));
 	fopt_set_str(&track_fopts[TF_OPUS], keyvals_get_val(info->comments, "opus"));
-	fopt_set_str(&track_fopts[TF_PARTNUMBER], keyvals_get_val(info->comments, "partnumber"));
-	fopt_set_str(&track_fopts[TF_PART], keyvals_get_val(info->comments, "part"));
+	fopt_set_str(&track_fopts[TF_PARTNUMBER], keyvals_get_val(info->comments, "discnumber"));
+	fopt_set_str(&track_fopts[TF_PART], keyvals_get_val(info->comments, "discnumber"));
 	fopt_set_str(&track_fopts[TF_SUBTITLE], keyvals_get_val(info->comments, "subtitle"));
 	fopt_set_str(&track_fopts[TF_MEDIA], info->media);
 	fopt_set_int(&track_fopts[TF_VA], 0, !track_is_compilation(info->comments));


### PR DESCRIPTION
It seems like that's probably the main intended use, for instance in id3v2 the disc number would be recorded in TPOS (Part Of Set). The name "part" is simply more generic as not everything is stored on discs.

As a real world reference, EasyTAG uses PART (and ignores DISCNUMBER) when reading/writing the "CD" field as an APE tag.

Fixes #1313.