### PR TITLE
Trim gaps from mp4 playback

### DIFF
--- a/ip/aac.c
+++ b/ip/aac.c
@@ -205,6 +205,7 @@ static void aac_get_channel_map(struct input_plugin_data *ip_data)
 		return;
 
 	buf = NeAACDecDecode(priv->decoder, &frame_info, buffer_data(ip_data), buffer_length(ip_data));
+	NeAACDecPostSeekReset(priv->decoder, 0);
 	if (!buf || frame_info.error != 0 || frame_info.bytesconsumed <= 0
 			|| frame_info.channels > CHANNELS_MAX)
 		return;
@@ -457,6 +458,8 @@ static int aac_duration(struct input_plugin_data *ip_data)
 
 	if (frames == 0)
 		return -IP_ERROR_FUNCTION_NOT_SUPPORTED;
+
+	NeAACDecPostSeekReset(priv->decoder, 0);
 
 	samples /= frames;
 	samples /= priv->channels;

--- a/utils.h
+++ b/utils.h
@@ -79,6 +79,11 @@ static inline long max_i(long a, long b)
 	return a > b ? a : b;
 }
 
+static inline unsigned long abs_delta(unsigned long a, unsigned long b)
+{
+	return a > b ? a - b : b - a;
+}
+
 static inline int clamp(int val, int minval, int maxval)
 {
 	if (val < minval)


### PR DESCRIPTION
At least for me there can sometimes still be soft clicks between tracks that aren't there when playing back the externally decoded wavs, but the buffer looks okay and gapless mp3 has the same clicks so I guess it's an unrelated hitch in the player or on the output side. In any case this is a very mild artifact compared to what we had before.

Closes #1280.