### PR TITLE
Remember playlist position when resume=true

### DIFF
--- a/job.c
+++ b/job.c
@@ -380,6 +380,7 @@ static void add_pl(const char *filename)
 		cmus_playlist_for_each(buf, size, reverse, handle_line, cwd);
 		free(cwd);
 		munmap(buf, size);
+		add_ti(NULL); // marks end of load
 	}
 }
 
@@ -421,7 +422,8 @@ static void job_handle_add_result(struct job_result *res)
 {
 	for (size_t i = 0; i < res->add_num; i++) {
 		res->add_cb(res->add_ti[i], res->add_opaque);
-		track_info_unref(res->add_ti[i]);
+		if (res->add_ti[i] != NULL)
+			track_info_unref(res->add_ti[i]);
 	}
 
 	free(res->add_ti);

--- a/lib.c
+++ b/lib.c
@@ -213,6 +213,9 @@ static bool track_exists(struct track_info *ti)
 
 void lib_add_track(struct track_info *ti, void *opaque)
 {
+	if (!ti)
+		return;
+
 	if (add_filter && !expr_eval(add_filter, ti)) {
 		/* filter any files excluded by lib_add_filter */
 		return;

--- a/options.c
+++ b/options.c
@@ -1893,6 +1893,11 @@ static int handle_resume_line(void *data, const char *line)
 	} else if (strcmp(cmd, "browser-dir") == 0) {
 		free(resume->browser_dir);
 		resume->browser_dir = xstrdup(unescape(arg));
+	} else if (strcmp(cmd, "active-pl") == 0) {
+		free(pl_resume_name);
+		pl_resume_name = xstrdup(unescape(arg));
+	} else if (strcmp(cmd, "active-pl-row") == 0) {
+		str_to_int(arg, &pl_resume_row);
 	} else if (strcmp(cmd, "marked-pl") == 0) {
 		free(resume->marked_pl);
 		resume->marked_pl = xstrdup(unescape(arg));
@@ -1966,6 +1971,7 @@ void resume_exit(void)
 {
 	char filename_tmp[512];
 	char filename[512];
+	const char *pl_name;
 	struct track_info *ti;
 	FILE *f;
 	int rc;
@@ -1993,6 +1999,11 @@ void resume_exit(void)
 	if (lib_live_filter)
 		fprintf(f, "live-filter %s\n", escape(lib_live_filter));
 	fprintf(f, "browser-dir %s\n", escape(browser_dir));
+
+	if ((pl_name = pl_playing_pl_name())) {
+		fprintf(f, "active-pl %s\n", escape(pl_name));
+		fprintf(f, "active-pl-row %d\n", pl_playing_pl_row());
+	}
 
 	fprintf(f, "marked-pl %s\n", escape(pl_marked_pl_name()));
 

--- a/pl.h
+++ b/pl.h
@@ -35,6 +35,9 @@ struct pl_list_info {
 extern struct window *pl_list_win;
 extern struct editable_shared pl_editable_shared;
 
+extern char *pl_resume_name;
+extern unsigned long pl_resume_row;
+
 void pl_init(void);
 void pl_init_options(void);
 void pl_exit(void);
@@ -69,6 +72,8 @@ int pl_get_cursor_in_track_window(void);
 int pl_visible_is_marked(void);
 const char *pl_marked_pl_name(void);
 void pl_set_marked_pl_by_name(const char *name);
+const char *pl_playing_pl_name(void);
+int pl_playing_pl_row(void);
 
 void pl_mark_for_redraw(void);
 int pl_needs_redraw(void);

--- a/play_queue.c
+++ b/play_queue.c
@@ -40,15 +40,19 @@ void play_queue_init(void)
 
 void play_queue_append(struct track_info *ti, void *opaque)
 {
-	struct simple_track *t = simple_track_new(ti);
+	if (!ti)
+		return;
 
+	struct simple_track *t = simple_track_new(ti);
 	editable_add(&pq_editable, t);
 }
 
 void play_queue_prepend(struct track_info *ti, void *opaque)
 {
-	struct simple_track *t = simple_track_new(ti);
+	if (!ti)
+		return;
 
+	struct simple_track *t = simple_track_new(ti);
 	editable_add_before(&pq_editable, t);
 }
 


### PR DESCRIPTION
Slightly overengineered as it could be done without a loaded event, but I wanted to avoid surprising behavior in the unlikely case where the playlist is cleared offline and then repopulated some time after cmus was started.

Fixes #729.