### PR TITLE
Fix view segv in rc config

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -711,6 +711,9 @@ version
 view <name or 1-7>
 	Changes the active view.
 
+	Do not use this in `$XDG_CONFIG_HOME/cmus/rc` to change the starting
+	view. Set the *start_view* option instead.
+
 vol [+-]NUM[%] [[+-]NUM[%]]
 	Changes the volume.
 

--- a/ui_curses.c
+++ b/ui_curses.c
@@ -1126,6 +1126,9 @@ static void update_pl_view(int full)
 
 static void do_update_view(int full)
 {
+	if (!ui_initialized)
+		return;
+
 	cursor_x = -1;
 	cursor_y = -1;
 


### PR DESCRIPTION
I noticed if I have a `view` command in my rc config (e.g. `view playlist`), cmus segfaults at startup. I can provide a more detailed backtrace if needed, but I thought it's clear enough what's happening from the description in the commit message in here.

I also added a note in the manpage to say not to use `view` in the rc; I assume you're not supposed to do that, because the `start_view` option exists instead. I feel like `view` used to either work or do nothing, for old versions from years ago, because I had this in my rc for an old install. Using `view` in the config could also throw an error, I wasn't sure what's preferred.