### PR TITLE
Fix configure function checks for recent clang versions

### DIFF
--- a/configure
+++ b/configure
@@ -503,9 +503,8 @@ check_string_function()
 	msg_checking "for function $1"
 	string_function_code="
 #include <string.h>
-int main() {
-	return $1;
-}
+int (*ptr)() = (int (*)()) &$1;
+int main() { return 0; }
 "
 	if try_compile_link "$string_function_code"
 	then

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -495,7 +495,7 @@ check_function()
 	__func="$1"
 	shift
 	msg_checking "for function $__func"
-	if try_compile_link "char $__func(); int main(int argc, char *argv[]) { return ((int*)(&$__func))[argc]; }" "$@"
+	if try_compile_link "extern int $__func(); int (*ptr)() = &$__func; int main() { return 0; }" "$@"
 	then
 		msg_result yes
 		return 0


### PR DESCRIPTION
Simply try taking the address of the function instead of doing funny stuff with the pointer.