### PR TITLE
Fix missing NCURSES_CFLAGS in configure try_compile_link

### DIFF
--- a/configure
+++ b/configure
@@ -193,7 +193,7 @@ check_ncurses()
 	msg_checking "for working ncurses setup"
 	for flag in "" "-I/usr/include/ncurses" "-I/usr/include/ncursesw"
 	do
-		if try_compile_link "$ncurses_code" $flag $NCURSES_LIBS
+		if try_compile_link "$ncurses_code" $NCURSES_CFLAGS $flag $NCURSES_LIBS
 		then
 			NCURSES_CFLAGS="$NCURSES_CFLAGS $flag"
 			msg_result yes


### PR DESCRIPTION
This makes it match the other libraries, and it's clearly a mistake since the line below appends NCURSES_CFLAGS.