### PR TITLE
Fix potential double-close in ip/mad

### DIFF
--- a/ip/mad.c
+++ b/ip/mad.c
@@ -54,8 +54,11 @@ static off_t lseek_func(void *datasource, off_t offset, int whence)
 static int close_func(void *datasource)
 {
 	struct input_plugin_data *ip_data = datasource;
+	int rc;
 
-	return close(ip_data->fd);
+	rc = ip_data->fd != -1 ? close(ip_data->fd) : 0;
+	ip_data->fd = -1;
+	return rc;
 }
 
 static struct nomad_callbacks callbacks = {


### PR DESCRIPTION
In input.c, ip_close calls ip->ops->close, then closes ip->data.fd (aka ip_data->fd) if fd is not -1. In ip/mad.c, close_func closes ip_data->fd without setting it to -1.

May be the cause of the fdsan failure reported in termux/termux-packages#18954. I've been looking at all the close calls and tracing the callers, and this seems to be the most likely issue.