### PR TITLE
Fix possible null dereference when continue_album=0

### DIFF
--- a/player.c
+++ b/player.c
@@ -835,7 +835,7 @@ static void _consumer_handle_eof(void)
 		ip = ip_new(ti->filename);
 		_producer_status_update(PS_STOPPED);
 		/* PS_STOPPED, CS_PLAYING */
-		if (player_cont && (player_cont_album == 1 || strcmp(player_info_priv.ti->album,ti->album) == 0)) {
+		if (player_cont && (player_cont_album == 1 || (player_info_priv.ti->album && ti->album && strcmp(player_info_priv.ti->album,ti->album) == 0))) {
 			_producer_play();
 			if (producer_status == PS_UNLOADED) {
 				_consumer_stop();


### PR DESCRIPTION
If continue_album=0 and the current or next track doesn't have album metadata, a strcmp with a null pointer will be done at the end of the track. Ensure track_info.album is non-null like other parts of cmus.

The continue_album option was added in f3ed07ee3d46b2bc98f98247654729b02457409b.