### PR TITLE
Improve compatibility with autoconf-style configure options

### DIFF
--- a/configure
+++ b/configure
@@ -562,7 +562,8 @@ Options:
   datadir         Read-only data         [\$prefix/share]
   libdir          Libraries              [\$prefix/lib]
   mandir          Man pages              [\$datadir/man]
-  exampledir      Examples               [\$datadir/doc/cmus/examples]
+  docdir          Other documentation    [\$datadir/doc/cmus]
+  exampledir      Examples               [\$docdir/examples]
   DEBUG           Debugging level (0-2)  [$DEBUG]
 
 Optional Features: y/n
@@ -620,7 +621,8 @@ var_default bindir "${prefix}/bin"
 var_default datadir "${prefix}/share"
 var_default libdir "${prefix}/lib"
 var_default mandir "${datadir}/man"
-var_default exampledir "${datadir}/doc/cmus/examples"
+var_default docdir "${datadir}/doc/cmus"
+var_default exampledir "${docdir}/examples"
 
 check check_cc
 check check_host_cc
@@ -706,7 +708,7 @@ config_header config/xmalloc.h HAVE_STRDUP HAVE_STRNDUP
 
 CFLAGS="${CFLAGS} -DHAVE_CONFIG"
 
-makefile_vars bindir datadir libdir mandir exampledir
+makefile_vars bindir datadir libdir mandir docdir exampledir
 makefile_vars \
 	CONFIG_AAC CONFIG_ALSA CONFIG_AO CONFIG_ARTS CONFIG_CDIO \
 	CONFIG_COREAUDIO CONFIG_CUE CONFIG_FFMPEG CONFIG_FLAC CONFIG_JACK \

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -17,6 +17,13 @@ parse_command_line()
 		--help)
 			show_usage
 			;;
+		--prefix=*|--bindir=*|--datadir=*|--libdir=*|--mandir=*|--docdir=*)
+			# aliases for compatibility with common autoconf options
+			# https://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/Installation-Directory-Variables.html
+			_var=`echo "$1" | sed "s/--//" | sed "s/=.*//"`
+			_val=`echo "$1" | sed "s/--${_var}=//"`
+			set_var "$_var" "$_val"
+			;;
 		-f)
 			shift
 			test $# -eq 0 && die "-f requires an argument"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -173,7 +173,7 @@ path_find()
 show_usage()
 {
 	cat <<EOF
-Usage ./configure [-f FILE] [OPTION=VALUE]...
+Usage ./configure [-f FILE] [--prefix|bindir|datadir|libdir|mandir|docdir=VALUE] [OPTION=VALUE]...
 
   -f FILE         Read OPTION=VALUE list from FILE (sh script)
 $USAGE


### PR DESCRIPTION
Many packages need a workaround for setting the prefix without this.

fixes #1261