### PR TITLE
Fix a couple of wrong *_attr defaults

### DIFF
--- a/options.c
+++ b/options.c
@@ -144,6 +144,7 @@ int attrs[NR_ATTRS] = {
 	A_NORMAL,
 	A_NORMAL,
 	A_NORMAL,
+	A_NORMAL,
 	A_BOLD,
 	A_NORMAL,
 };


### PR DESCRIPTION
I missed updating the values list when adding `color_statusline_progress_attr`. This was causing the "bold" to match with `color_win_title_attr` instead of `color_trackwin_album_attr`.