### PR TITLE
Fix load command args

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -477,16 +477,13 @@ live-filter <simple-filter-expression|short-filter-expression>
 	Like filter, but uses simple filters and shows a preview as you type. It
 	persists even after leaving command mode.
 
-load [-l] [-p] <playlist>
+load [-l] <playlist>
 	Loads a playlist to a view.
 
 	@li -l
 	load to library views
 
-	@li -p
-	load to playlist view
-
-	If a view is not specified, the current view is used.
+	If a view is not specified, the current view is used, which must be 1-2.
 
 lqueue [NUM]
 	Queues NUM (default 1) random albums from the library. Also see

--- a/command_mode.c
+++ b/command_mode.c
@@ -383,7 +383,7 @@ static void cmd_clear(char *arg)
 
 static void cmd_load(char *arg)
 {
-	int flag = parse_flags((const char **)&arg, "lp");
+	int flag = parse_flags((const char **)&arg, "l");
 
 	if (flag == -1)
 		return;


### PR DESCRIPTION
The `load -p whatever.pl` command does not work, and results in the error `:load only works in views 1-2`.

The `load whatever.pl` command only works in views 1-2.

The `load -l whatever.pl` works in all views.

The initial implementation of the load command was done in 8d3cbc51fb13d91468c768dfc683f8101f670825, and was consistent with the documentation added in eec4e5e819c7af1586d544d841f1fac273796ee0.

Support for loading into the playlist view was intentionally dropped in 5563e0c94bfca08c08628007abc477e47437fec3, but the documentation and arg parsing was not updated.

fixes #1304