### PR TITLE
Set the minimum requested AAudio buffer capacity

### DIFF
--- a/Doc/cmus.txt
+++ b/Doc/cmus.txt
@@ -1541,6 +1541,12 @@ dsp.aaudio.disable_spatialization (false)
 	This option is only supported on Android 12L+ (API 32) and requires
 	restarting cmus.
 
+dsp.aaudio.min_buffer_capacity_ms (0)
+	If non-zero, sets the requested minimum buffer capacity for the AAudio
+	stream. The lower bound depends on the playback device. Lower values may
+	result in buffer underruns. Higher values result in lower CPU usage, but
+	may make the UI laggy. If left unset, a sensible default is used.
+
 input.cdio.cddb_url
 	CDDB URL (default: freedb.freedb.org:8880). Uses HTTP if prefixed with
 	"http://" (e.g.: http://freedb.musicbrainz.org:80/~cddb/cddb.cgi). Set

--- a/op/aaudio.c
+++ b/op/aaudio.c
@@ -556,6 +556,9 @@ static int op_aaudio_open(sample_format_t sf, const channel_position_t *channel_
 	if (API_AT_LEAST(31)) AAudioStreamBuilder_setAttributionTag(bld, "cmus");
 	if (API_AT_LEAST(32)) AAudioStreamBuilder_setSpatializationBehavior(bld, op_aaudio_opt_disable_spatialization ? AAUDIO_SPATIALIZATION_BEHAVIOR_NEVER : AAUDIO_SPATIALIZATION_BEHAVIOR_AUTO);
 
+	// ensure the buffer holds at least 80ms of audio
+	AAudioStreamBuilder_setBufferCapacityInFrames(bld, sf_get_rate(sf) / (1000 / 80));
+
 	// configure the sample format and channel map
 	rc = configure_aaudio_sf(bld, sf, channel_map, &op.remap);
 	if (rc) {


### PR DESCRIPTION
This fixes buffer underruns on the Pixel 9 due to the default selected buffer size being faster than cmus can produce audio.

There's probably a better way to deal with this, but it works.