### PR TITLE
fix: MPRIS seeked signals reporting old position instead of new

### DIFF
--- a/player.c
+++ b/player.c
@@ -74,6 +74,7 @@ static struct player_info player_info_priv = {
 	.metadata_changed = 0,
 	.status_changed = 0,
 	.position_changed = 0,
+	.position_seeked = 0,
 	.buffer_fill_changed = 0,
 };
 
@@ -548,6 +549,17 @@ static void _consumer_position_update(void)
 		player_info_priv.position_changed = 1;
 		player_info_priv_unlock();
 	}
+}
+
+/*
+ * position is seeked
+ */
+static void _player_position_seeked(void)
+{
+	player_info_priv_lock();
+	player_info_priv.position_seeked = 1;
+	player_info_priv_unlock();
+	_consumer_position_update();
 }
 
 /*
@@ -1293,7 +1305,7 @@ void player_seek(double offset, int relative, int start_playing)
 			reset_buffer();
 			consumer_pos = new_pos * buffer_second_size();
 			scale_pos = consumer_pos;
-			_consumer_position_update();
+			_player_position_seeked();
 			if (stopped && !start_playing) {
 				_producer_pause();
 				_consumer_pause();
@@ -1304,7 +1316,6 @@ void player_seek(double offset, int relative, int start_playing)
 			d_print("error: ip_seek returned %d\n", rc);
 		}
 	}
-	mpris_seeked();
 	player_unlock();
 }
 
@@ -1480,6 +1491,7 @@ void player_info_snapshot(void)
 	player_info_priv.metadata_changed = 0;
 	player_info_priv.status_changed = 0;
 	player_info_priv.position_changed = 0;
+	player_info_priv.position_seeked = 0;
 	player_info_priv.buffer_fill_changed = 0;
 	player_info_priv.error_msg = NULL;
 

--- a/player.h
+++ b/player.h
@@ -69,6 +69,7 @@ struct player_info {
 	unsigned int metadata_changed : 1;
 	unsigned int status_changed : 1;
 	unsigned int position_changed : 1;
+	unsigned int position_seeked : 1;
 	unsigned int buffer_fill_changed : 1;
 };
 

--- a/ui_curses.c
+++ b/ui_curses.c
@@ -1979,6 +1979,9 @@ static void update(void)
 	if (player_info.file_changed || player_info.metadata_changed)
 		mpris_metadata_changed();
 
+	if (player_info.position_seeked)
+		mpris_seeked();
+
 	needs_spawn = player_info.status_changed || player_info.file_changed ||
 		player_info.metadata_changed;
 


### PR DESCRIPTION
Fixing #1407, probably in a hacky way. Would've been great if someone knowledgeable took a look and said if it's OK as it is.

On that note I would also like to ask: why don't we make the seeking strict to integers, or the seeked signal to be sent with the most possible accuracy? Just curious, as I would love to see the consistency between the arrived info from DBus and the actual seeked position.