### PR TITLE
[CI] Update dependency list to fix ubuntu build setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,12 +27,12 @@ jobs:
         run: |
           sudo apt-get update -qyy
           sudo apt-get install -qyy \
-            bash-completion libao-dev libasound2-dev libavcodec-dev \
-            libavformat-dev libswresample-dev libcddb2-dev libcdio-cdda-dev \
-            libcue-dev libdiscid-dev libfaad-dev libflac-dev libjack-dev \
-            libmad0-dev libmodplug-dev libmpcdec-dev libncursesw5-dev \
-            libopusfile-dev libpulse-dev libroar-dev libsamplerate0-dev \
-            libsndio-dev libvorbis-dev libwavpack-dev libsystemd-dev pkg-config
+            pkg-config libncursesw5-dev libfaad-dev libao-dev libasound2-dev \
+            libcddb2-dev libcdio-cdda-dev libdiscid-dev libavformat-dev \
+            libavcodec-dev libswresample-dev libflac-dev libjack-dev \
+            libmad0-dev libmodplug-dev libmpcdec-dev libsystemd-dev \
+            libopusfile-dev libpulse-dev libsamplerate0-dev libsndio-dev \
+            libvorbis-dev libwavpack-dev
       - name: Build
         run: |
           ./configure CC="${{matrix.cc}}"


### PR DESCRIPTION
The updated list (including order) is copied directly from the README. No additions. Removals:

- bash-completion (not used)
- libcue-dev (not used)
- libroar-dev (no longer available, breaking the CI build)