### PR TITLE
Try to fallback to any plugin upon failure to init output plugin

### DIFF
--- a/player.c
+++ b/player.c
@@ -1313,7 +1313,7 @@ void player_seek(double offset, int relative, int start_playing)
  */
 void player_set_op(const char *name)
 {
-	int rc;
+	int rc = 0;
 
 	player_lock();
 
@@ -1327,11 +1327,20 @@ void player_set_op(const char *name)
 	if (name) {
 		d_print("setting op to '%s'\n", name);
 		rc = op_select(name);
-	} else {
-		/* first initialized plugin */
+	}
+
+	/*
+	 * if plugin is null we either never selected one and will now try any,
+	 * or we tried and failed and will now try to fallback to any
+	 */
+	if (op_get_current() == NULL) {
+		if (rc)
+			player_op_error(rc, "selecting output plugin '%s'", name);
+
 		d_print("selecting first initialized op\n");
 		rc = op_select_any();
 	}
+
 	if (rc) {
 		_consumer_status_update(CS_STOPPED);
 

--- a/player.c
+++ b/player.c
@@ -31,6 +31,7 @@
 #include "cmus.h"
 #include "lib.h"
 #include "pl_env.h"
+#include "ui_curses.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -1329,12 +1330,13 @@ void player_set_op(const char *name)
 		rc = op_select(name);
 	}
 
-	/*
-	 * if plugin is null we either never selected one and will now try any,
-	 * or we tried and failed and will now try to fallback to any
-	 */
-	if (op_get_current() == NULL) {
+	/* when at startup and plugin is null, op_select_any() */
+	if (!ui_initialized && op_get_current() == NULL) {
 		if (rc)
+			/*
+			 * error if we are falling back because
+			 * the specified init plugin failed
+			 */
 			player_op_error(rc, "selecting output plugin '%s'", name);
 
 		d_print("selecting first initialized op\n");


### PR DESCRIPTION
Bad values for output_plugin set in ~/.config/cmus/rc or ~/.config/cmus/autosave prevent output_plugin from being initialized.

This fixes that.