### PR TITLE
Clear the marked playlist when focus is in the playlist list

### DIFF
--- a/pl.c
+++ b/pl.c
@@ -546,6 +546,16 @@ static void pl_clear_visible_pl(void)
 	pl_cancel_add_jobs(pl_visible);
 }
 
+static void pl_clear_marked_pl(void)
+{
+	if (pl_cursor_in_track_window)
+		pl_win_next();
+	if (pl_marked == pl_playing)
+		pl_playing_track = NULL;
+	editable_clear(&pl_marked->editable);
+	pl_cancel_add_jobs(pl_marked);
+}
+
 static int pl_name_exists(const char *name)
 {
 	struct playlist *pl;
@@ -795,10 +805,10 @@ void pl_rename_selected_pl(const char *name)
 
 void pl_clear(void)
 {
-	if (!pl_cursor_in_track_window)
-		return;
-
-	pl_clear_visible_pl();
+	if (pl_cursor_in_track_window)
+		pl_clear_visible_pl();
+	else
+		pl_clear_marked_pl();
 }
 
 void pl_mark_for_redraw(void)


### PR DESCRIPTION
Fixes #1423. This PR allows users to clear the marked playlist when focused in the playlist list (left view). 

I opted to clear the marked playlist rather than the visible playlist as this has the same functionality as the `add` command. However, when selected the playlist that is visible will still be cleared. This may be confusing to users though, so I'm up for changing this to always clear the visible playlist (frankly, I think add working on marked playlists instead of visible playlists is confusing).

### Implementation notes
Although `pl_cursor_in_track_window` is currently always true when `pl_clear_marked_pl` is called, I still kept the check in there in case it will be used for other situations later and to keep congruency with `pl_clear_visible_pl`. I can remove this check if it's deemed unnecessary and just note that `pl_cursor_in_track_window` is assumed to be true in a comment.