### PR TITLE
op/mixer_alsa: alsamixer's volume scale; setting mixer control like aplay does it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ op/pulse.so: $(pulse-objs) $(libcmus-y)
 	$(call cmd,ld_dl,$(PULSE_LIBS))
 
 op/alsa.so: $(alsa-objs) $(libcmus-y)
-	$(call cmd,ld_dl,$(ALSA_LIBS))
+	$(call cmd,ld_dl,$(ALSA_LIBS) -lm)
 
 op/jack.so: $(jack-objs) $(libcmus-y)
 	$(call cmd,ld_dl,$(JACK_LIBS) $(SAMPLERATE_LIBS))

--- a/op/alsa.c
+++ b/op/alsa.c
@@ -210,8 +210,6 @@ error:
 	return alsa_error_to_op_error(rc);
 }
 
-static int op_alsa_write(const char *buffer, int count);
-
 static int op_alsa_close(void)
 {
 	int rc;

--- a/op/mixer_alsa.c
+++ b/op/mixer_alsa.c
@@ -22,6 +22,7 @@
 #include "../debug.h"
 
 #include <strings.h>
+#include <math.h>
 
 #define ALSA_PCM_NEW_HW_PARAMS_API
 #define ALSA_PCM_NEW_SW_PARAMS_API
@@ -30,11 +31,11 @@
 
 static snd_mixer_t *mixer;
 static snd_mixer_elem_t *mixer_elem = NULL;
-static long mixer_vol_min, mixer_vol_max;
 
 /* configuration */
 static char *alsa_mixer_device = NULL;
 static char *alsa_mixer_element = NULL;
+static int alsa_mixer_mapped_volume = 1;
 
 static int alsa_mixer_init(void)
 {
@@ -101,18 +102,17 @@ static int alsa_mixer_open(int *volume_max)
 
 	elem = find_mixer_elem_by_name(alsa_mixer_element);
 	if (!elem) {
-		d_print("mixer element '%s' not found, trying 'Master'\n", alsa_mixer_element);
+		d_print("mixer element '%s' not found, trying 'Master'\n",
+				alsa_mixer_element);
 		elem = find_mixer_elem_by_name("Master");
 		if (!elem) {
 			d_print("error: cannot find suitable mixer element\n");
 			return -2;
 		}
 	}
-	snd_mixer_selem_get_playback_volume_range(elem, &mixer_vol_min, &mixer_vol_max);
-	/* FIXME: get number of channels */
-	mixer_elem = elem;
-	*volume_max = mixer_vol_max - mixer_vol_min;
 
+	mixer_elem = elem;
+	*volume_max = 100;
 	return 0;
 error:
 	d_print("error: %s\n", snd_strerror(rc));
@@ -141,35 +141,96 @@ static int alsa_mixer_get_fds(int what, int *fds)
 	}
 }
 
+static void alsa_mixer_get_range(long *min, long *max, int *linear_mapping)
+{
+	if (!*linear_mapping) {
+		int err = snd_mixer_selem_get_playback_dB_range(
+				mixer_elem, min, max);
+		*linear_mapping = err != 0 || *min >= *max;
+
+		/* Force linear mapping for small ranges of 24 dB */
+		enum { max_linear_db_scale = 24 };
+		*linear_mapping |= *max - *min <= max_linear_db_scale * 100;
+	}
+	if (*linear_mapping)
+		snd_mixer_selem_get_playback_volume_range(mixer_elem, min, max);
+}
+
+static void alsa_mixer_set_vol(snd_mixer_selem_channel_id_t channel,
+		long min, long max, int vol, int linear_mapping)
+{
+	if (linear_mapping) {
+		long v = (long)(vol * (max - min) / 100.0 + 0.5) + min;
+		snd_mixer_selem_set_playback_volume(mixer_elem, channel, v);
+	} else {
+		/* alsamixer's volume mapping */
+		double norm = vol / 100.0;
+		if (min != SND_CTL_TLV_DB_GAIN_MUTE) {
+			double min_norm = pow(10, (min - max) / 6000.0);
+			norm = norm * (1 - min_norm) + min_norm;
+		}
+		if (norm <= 0)
+			norm = 1e-36;
+		long v = (long)(6000.0 * log10(norm) + 0.5) + max;
+		snd_mixer_selem_set_playback_dB(mixer_elem, channel, v, 0);
+	}
+}
+
 static int alsa_mixer_set_volume(int l, int r)
 {
-	if (mixer_elem == NULL) {
+	int linear_mapping = !alsa_mixer_mapped_volume;
+	long min, max;
+
+	if (!mixer_elem)
 		return -1;
-	}
-	l += mixer_vol_min;
-	r += mixer_vol_min;
-	if (l > mixer_vol_max)
-		d_print("error: left volume too high (%d > %ld)\n",
-				l, mixer_vol_max);
-	if (r > mixer_vol_max)
-		d_print("error: right volume too high (%d > %ld)\n",
-				r, mixer_vol_max);
-	snd_mixer_selem_set_playback_volume(mixer_elem, SND_MIXER_SCHN_FRONT_LEFT, l);
-	snd_mixer_selem_set_playback_volume(mixer_elem, SND_MIXER_SCHN_FRONT_RIGHT, r);
+
+	snd_mixer_handle_events(mixer);
+
+	alsa_mixer_get_range(&min, &max, &linear_mapping);
+
+	alsa_mixer_set_vol(SND_MIXER_SCHN_FRONT_LEFT,
+			min, max, l, linear_mapping);
+	alsa_mixer_set_vol(SND_MIXER_SCHN_FRONT_RIGHT,
+			min, max, r, linear_mapping);
 	return 0;
+}
+
+static int alsa_mixer_get_vol(snd_mixer_selem_channel_id_t channel,
+		long min, long max, int linear_mapping)
+{
+	long val;
+
+	if (linear_mapping) {
+		snd_mixer_selem_get_playback_volume(mixer_elem, channel, &val);
+		return ((val - min) / (double)(max - min) * 100) + 0.5;
+	}
+
+	/* alsamixer's volume mapping */
+	snd_mixer_selem_get_playback_dB(mixer_elem, channel, &val);
+	double normalized = pow(10, (val - max) / 6000.0);
+	if (min != SND_CTL_TLV_DB_GAIN_MUTE) {
+		double min_norm = pow(10, (min - max) / 6000.0);
+		normalized = (normalized - min_norm) / (1 - min_norm);
+	}
+	return normalized * 100.0 + 0.5;
 }
 
 static int alsa_mixer_get_volume(int *l, int *r)
 {
-	long lv, rv;
+	int linear_mapping = !alsa_mixer_mapped_volume;
+	long min, max;
 
-	if (mixer_elem == NULL)
+	if (!mixer_elem)
 		return -1;
+
 	snd_mixer_handle_events(mixer);
-	snd_mixer_selem_get_playback_volume(mixer_elem, SND_MIXER_SCHN_FRONT_LEFT, &lv);
-	snd_mixer_selem_get_playback_volume(mixer_elem, SND_MIXER_SCHN_FRONT_RIGHT, &rv);
-	*l = lv - mixer_vol_min;
-	*r = rv - mixer_vol_min;
+
+	alsa_mixer_get_range(&min, &max, &linear_mapping);
+
+	*l = alsa_mixer_get_vol(SND_MIXER_SCHN_FRONT_LEFT,
+			min, max, linear_mapping);
+	*r = alsa_mixer_get_vol(SND_MIXER_SCHN_FRONT_RIGHT,
+			min, max, linear_mapping);
 	return 0;
 }
 
@@ -201,6 +262,18 @@ static int alsa_mixer_get_device(char **val)
 	return 0;
 }
 
+static int alsa_mixer_set_mapped_volume(const char *val)
+{
+	alsa_mixer_mapped_volume = atoi(val);
+	return 0;
+}
+
+static int alsa_mixer_get_mapped_volume(char **val)
+{
+	*val = alsa_mixer_mapped_volume ? xstrdup("1") : xstrdup("0");
+	return 0;
+}
+
 const struct mixer_plugin_ops op_mixer_ops = {
 	.init = alsa_mixer_init,
 	.exit = alsa_mixer_exit,
@@ -214,5 +287,6 @@ const struct mixer_plugin_ops op_mixer_ops = {
 const struct mixer_plugin_opt op_mixer_options[] = {
 	OPT(alsa_mixer, channel),
 	OPT(alsa_mixer, device),
+	OPT(alsa_mixer, mapped_volume),
 	{ NULL },
 };


### PR DESCRIPTION
I'm spamming at this point, but this is pretty useful :)

Alsamixer and i3status and aplay (with -M flag) display so-called 'mapped volume' by default (see `man alsamixer` "VOLUME MAPPING"), so I added it to alsa mixer plugin. `mixer.alsa.mapped_volume` config option turns it on. It's enabled by default because Alsamixer and i3status do it, I think its ok.