### PR TITLE
Fix for missing Icecast streaming bitrate display.

### DIFF
--- a/input.c
+++ b/input.c
@@ -321,6 +321,10 @@ static int setup_remote(struct input_plugin *ip, const struct keyval *headers, i
 	if (val)
 		ip->data.icy_url = to_utf8(val, icecast_default_charset);
 
+	val = keyvals_get_val(headers, "icy-br");
+	if (val)
+		ip->data.icy_br = to_utf8(val, icecast_default_charset);
+
 	return 0;
 }
 
@@ -659,6 +663,7 @@ int ip_close(struct input_plugin *ip)
 	free(ip->data.icy_name);
 	free(ip->data.icy_genre);
 	free(ip->data.icy_url);
+	free(ip->data.icy_br);
 	free(ip->http_reason);
 
 	ip_init(ip, ip->data.filename);
@@ -757,6 +762,9 @@ int ip_read_comments(struct input_plugin *ip, struct keyval **comments)
 
 		if (ip->data.icy_url && !keyvals_get_val_growing(&c, "comment"))
 			keyvals_add(&c, "comment", xstrdup(ip->data.icy_url));
+
+		if (ip->data.icy_br && !keyvals_get_val_growing(&c, "bitrate"))
+			keyvals_add(&c, "bitrate", xstrdup(ip->data.icy_br));
 
 		keyvals_terminate(&c);
 

--- a/ip.h
+++ b/ip.h
@@ -78,6 +78,7 @@ struct input_plugin_data {
 	char *icy_name;
 	char *icy_genre;
 	char *icy_url;
+	char *icy_br;
 
 	/* filled by plugin */
 	sample_format_t sf;

--- a/ip/ffmpeg.c
+++ b/ip/ffmpeg.c
@@ -327,7 +327,7 @@ static void ffmpeg_skip_frame_part(struct ffmpeg_private *priv)
 	} else {
 		priv->frame->extended_data[0] += priv->skip_samples * channels * bps;
 	}
-	d_print("skipping %ld samples\n", priv->skip_samples);
+	d_print("skipping %lld samples\n", priv->skip_samples);
 	priv->skip_samples = 0;
 }
 

--- a/track_info.c
+++ b/track_info.c
@@ -85,6 +85,11 @@ void track_info_set_comments(struct track_info *ti, struct keyval *comments) {
 	ti->is_va_compilation = track_is_va_compilation(comments);
 	ti->media = keyvals_get_val(comments, "media");
 
+	const char *bitrate_str = keyvals_get_val(comments, "bitrate");
+	if (bitrate_str) {
+		ti->bitrate = strtol(bitrate_str, NULL, 10) * 1000;
+	}
+
 	int bpm = comments_get_int(comments, "bpm");
 	if (ti->bpm == 0 || ti->bpm == -1) {
 		ti->bpm = bpm;


### PR DESCRIPTION
If a stream specifies its bitrate in an "icy-br" header, we can use it to populate the bitrate in the track info. Without this fix, no bitrate was displayed for a stream, either in the track info or the status bar.

Also changed a print format specifier from %ld to %lld to fix a warning as the former is too small for the int64_t type.