### PR TITLE
ip/ffmpeg: fix seeking and compiler warning about %lld

### DIFF
--- a/ip/ffmpeg.c
+++ b/ip/ffmpeg.c
@@ -437,7 +437,7 @@ static int ffmpeg_seek(struct input_plugin_data *ip_data, double offset)
 
 	priv->seek_ts = offset;
 	priv->skip_samples = 0;
-	int64_t ts = av_rescale(offset, st->time_base.den, st->time_base.num);
+	int64_t ts = offset / av_q2d(st->time_base);
 
 	int ret = avformat_seek_file(priv->format_ctx,
 			priv->stream_index, 0, ts, ts, 0);


### PR DESCRIPTION
### About %lld

[3157b78](https://github.com/cmus/cmus/commit/3157b788a7eeb8d1a02d6dad2c05fde6f900f4aa) introduced a warning about %lld on GCC. @thecloudexpanse try this PR with your compiler please

### Results of the seeking fix
Before:
```
ffmpeg_calc_skip_samples: seek_ts: 98.673288s, frame_ts: 97.985306s
ffmpeg_skip_frame_part: skipping frame: 1152 samples
... 24 more ...
ffmpeg_skip_frame_part: skipping frame: 1152 samples
ffmpeg_skip_frame_part: skipping 388 samples
```
After:
```
ffmpeg_calc_skip_samples: seek_ts: 98.673288s, frame_ts: 98.664490s
ffmpeg_skip_frame_part: skipping 388 samples
```