### PR TITLE
Natural sort playlist names in pl_list_compare

### DIFF
--- a/misc.h
+++ b/misc.h
@@ -31,6 +31,7 @@ extern const char *home_dir;
 char **get_words(const char *text);
 int strptrcmp(const void *a, const void *b);
 int strptrcoll(const void *a, const void *b);
+int strptrnatcmp(const void *a, const void *b);
 int misc_init(void);
 const char *escape(const char *str);
 const char *unescape(const char *str);

--- a/pl.c
+++ b/pl.c
@@ -259,7 +259,7 @@ static int pl_list_compare(const struct list_head *l, const struct list_head *r)
 {
 	struct playlist *pl = pl_from_list(l);
 	struct playlist *pr = pl_from_list(r);
-	return strcmp(pl->name, pr->name);
+	return strptrnatcmp(&pl->name, &pr->name);
 }
 
 static void pl_sort_all(void)

--- a/utils.h
+++ b/utils.h
@@ -137,6 +137,11 @@ static inline int is_space(const char ch)
 	return (ch == ' ' || ch == '\t');
 }
 
+static inline int is_digit(const char ch)
+{
+	return (ch >= '0' && ch <= '9');
+}
+
 static inline int ends_with(const char *str, const char *suffix)
 {
 	return strstr(str, suffix) + strlen(suffix) == str + strlen(str);


### PR DESCRIPTION
Playlists with equal names up to a number are now displayed in numerical ascending order.

Previously:
- Volume 11
- Volume 25
- Volume 9

Now:
- Volume 9
- Volume 11
- Volume 25

Leading zeros are ignored, but items with more leading zeros (but equal otherwise) appear later in the list.