### PR TITLE
Fix libmp4v2 check

### DIFF
--- a/configure
+++ b/configure
@@ -452,7 +452,7 @@ check_mp4()
 {
 	pkg_config MP4 "mp4v2 faad2" "" "-lmp4v2 -lfaad -lm" || return $?
 	USE_MPEG4IP=0
-	if ! check_header mp4v2/mp4v2.h $MP4_CFLAGS
+	if ! check_header mp4v2/mp4v2.h -std=c11 $MP4_CFLAGS
 	then
 		# couldn't find the v2 header, try falling back to mp4.h
 		USE_MPEG4IP=1


### PR DESCRIPTION
The modern gcc default is -std=gnu23 which the mp4v2 headers are not compatible with. This was only a problem for the check, since for the actual compile we add EXTRA_CFLAGS that set -std=gnu11 or -std=c11 anyway.