### PR TITLE
Make sure to not try freeing an uninitialized pointer

### DIFF
--- a/job.c
+++ b/job.c
@@ -328,6 +328,8 @@ static void handle_cue_files(struct ptr_array *files)
 
 		char **files_in_cue;
 		int n = cue_get_files(ents[i], &files_in_cue);
+		if (n == -1) 
+			continue;
 		char *cue_dir = path_dirname(ents[i]);
 
 		for (j = 0; j < n; j++) {


### PR DESCRIPTION
While playing around with cmus and trying to load my Music archive I stumbled upon this bug ... reported as double free but actually trying to free an unitialized pointer.