### PR TITLE
Fix unterminated-string-initialization warnings

### DIFF
--- a/cache.c
+++ b/cache.c
@@ -51,7 +51,7 @@
 #define CACHE_ENTRY_TOTAL_SIZE	(CACHE_ENTRY_RESERVED_SIZE + CACHE_ENTRY_USED_SIZE)
 
 // Cmus Track Cache version X + 4 bytes flags
-static char cache_header[8] = "CTC\0\0\0\0\0";
+static char cache_header[8] CMUS_NONSTRING = "CTC\0\0\0\0\0";
 
 // host byte order
 // mtime is either 32 or 64 bits

--- a/compiler.h
+++ b/compiler.h
@@ -67,6 +67,17 @@
 
 #endif
 
+#if defined(__GNUC__) && (__GNUC__ >= 8)
+
+/* Silences the unterminated-string-initialization warnings */
+#define CMUS_NONSTRING __attribute__((nonstring))
+
+#else
+
+#define CMUS_NONSTRING
+
+#endif
+
 
 /**
  * container_of - cast a member of a structure out to the containing structure

--- a/expr.c
+++ b/expr.c
@@ -71,7 +71,7 @@ struct token {
 };
 
 /* same order as TOK_* */
-static const char specials[NR_SPECIALS] = "!<>=&|()";
+static const char specials[NR_SPECIALS] CMUS_NONSTRING = "!<>=&|()";
 
 static const int tok_to_op[NR_TOKS] = {
 	-1, OP_LT, OP_GT, OP_EQ, -1, -1, -1, -1, OP_NE, OP_LE, OP_GE, -1, -1, -1

--- a/http.c
+++ b/http.c
@@ -453,7 +453,7 @@ void http_get_free(struct http_get *hg)
 
 char *base64_encode(const char *str)
 {
-	static const char t[64] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+	static const char t[64] CMUS_NONSTRING = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 	int str_len, buf_len, i, s, d;
 	char *buf;
 	unsigned char b0, b1, b2;

--- a/uchar.c
+++ b/uchar.c
@@ -32,7 +32,7 @@
 #include "unidecomp.h"
 #include "wcwidth_uchar.h"
 
-const char hex_tab[16] = "0123456789abcdef";
+const char hex_tab[16] CMUS_NONSTRING = "0123456789abcdef";
 
 /*
  * Byte Sequence                                             Min       Min        Max

--- a/ui_curses.c
+++ b/ui_curses.c
@@ -863,7 +863,7 @@ static void print_filter(struct window *win, int row, struct iter *iter)
 	int selected;
 	/* is the filter currently active? */
 	int current = !!e->act_stat;
-	const char stat_chars[3] = " *!";
+	const char stat_chars[3] CMUS_NONSTRING = " *!";
 	int ch1, ch2, ch3;
 	const char *e_filter;
 


### PR DESCRIPTION
When compiling cmus I get multiple warnings around unterminated string initialization. This patch fixes the warnings by replacing the string initializers with explicit char initializers to avoid truncation of null terminator.