### PR TITLE
Fix stringop-truncation warning

### DIFF
--- a/pl_env.c
+++ b/pl_env.c
@@ -195,7 +195,7 @@ char *pl_env_reduce(const char *path)
 		char *new, *ptr;
 		new = ptr = xmalloc(1+var_len+1+rem_len+1);
 		*ptr++ = PL_ENV_DELIMITER;
-		strncpy(ptr, *var, var_len);
+		memcpy(ptr, *var, var_len);
 		ptr += var_len;
 		*ptr++ = PL_ENV_DELIMITER;
 		strcpy(ptr, rem);


### PR DESCRIPTION
When compiling with gcc 15.2.1 I get the following warning: pl_env.c:198:17: warning: 'strncpy' output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation].

Having a look at the code, it seems that strncpy is used to copy a string where the specified length equals the source string length, resulting in no null terminator being written. The code is explicitly handing the string construction in this case, adding delimiters and a final null terminator later. So the null-padding behaviour of strncpy is not really needed and we should directly use memcpy instead to fix the truncation warning.
