### PR TITLE
Standardise in using xmalloc

### DIFF
--- a/id3.c
+++ b/id3.c
@@ -734,7 +734,7 @@ static void decode_normal(struct id3tag *id3, const char *buf, int len, int enco
 			return;
 		}
 	} else if (key == ID3_PUBLISHER) {
-		 add_v2(id3, ID3_LABEL, strdup(out));
+		 add_v2(id3, ID3_LABEL, xstrdup(out));
 	}
 
 	add_v2(id3, key, out);

--- a/ip/bass.c
+++ b/ip/bass.c
@@ -111,7 +111,7 @@ static unsigned char *encode_ascii_string(const char *str)
 	unsigned char *ret;
 	int n;
 
-	ret = malloc(strlen(str) + 1);
+	ret = xmalloc(strlen(str) + 1);
 	n = u_to_ascii(ret, str, strlen(str));
 	ret[n] = '\0';
 	return ret;

--- a/op/aaudio.c
+++ b/op/aaudio.c
@@ -202,10 +202,7 @@ static ssize_t *make_channel_remap(const channel_position_t *channel_map_out, co
 	int byte, channel_out, channel_in;
 	ssize_t *map;
 
-	map = malloc(sizeof(ssize_t) * (size_t) sf_get_frame_size(sf));
-	if (!map) {
-		return NULL;
-	}
+	map = xnew(ssize_t, sf_get_frame_size(sf));
 
 	if (!channel_map_out || !channel_map_valid(channel_map_out) || !channel_map_in || !channel_map_valid(channel_map_in)) {
 		for (byte = 0; byte < sf_get_frame_size(sf); byte++) {

--- a/op/coreaudio.c
+++ b/op/coreaudio.c
@@ -113,7 +113,7 @@ static int coreaudio_ring_buffer_init(coreaudio_ring_buffer_t *rbuf, size_t num_
 	if (((num_of_bytes - 1) & num_of_bytes) != 0)
 		return -1;				/*Not Power of two. */
 	rbuf->buffer_size = num_of_bytes;
-	rbuf->buffer = (char *)malloc(num_of_bytes);
+	rbuf->buffer = (char *)xmalloc(num_of_bytes);
 	coreaudio_ring_buffer_flush(rbuf);
 	rbuf->big_mask = (num_of_bytes *2) - 1;
 	rbuf->small_mask = (num_of_bytes) - 1;
@@ -374,7 +374,7 @@ static void coreaudio_set_channel_position(AudioDeviceID dev_id,
 	};
 	AudioChannelLayout *layout = NULL;
 	size_t layout_size = (size_t) &layout->mChannelDescriptions[channels];
-	layout = (AudioChannelLayout*)malloc(layout_size);
+	layout = (AudioChannelLayout*)xmalloc(layout_size);
 	layout->mChannelLayoutTag = kAudioChannelLayoutTag_UseChannelDescriptions ;
 	layout->mChannelBitmap = 0;
 	layout->mNumberChannelDescriptions = channels;


### PR DESCRIPTION
Replaces all instances of raw `malloc` and `strdup` with the `xmalloc`, `xnew`, and `xstrdup` wrappers defined in `xmalloc.h`.

Previously, raw allocations often lacked NULL checks, risking segmentation faults if memory allocation failed. Using the wrappers ensures consistent error handling and safety across the codebase.