### PR TITLE
Fix compiler warning about uninitialized rb_parent_color

### DIFF
--- a/rbtree.h
+++ b/rbtree.h
@@ -135,7 +135,7 @@ static inline void rb_set_color(struct rb_node *rb, int color)
 
 #define RB_EMPTY_ROOT(root)	((root)->rb_node == NULL)
 #define RB_EMPTY_NODE(node)	(rb_parent(node) == node)
-#define RB_CLEAR_NODE(node)	(rb_set_parent(node, node))
+#define RB_CLEAR_NODE(node)	((node)->rb_parent_color = (unsigned long)(node))
 
 void rb_insert_color(struct rb_node *, struct rb_root *);
 void rb_erase(struct rb_node *, struct rb_root *);


### PR DESCRIPTION
When compiling with GCC 15.2.1, the compiler issues a maybe-uninitialized warning with message: rb_parent_color may be used uninitialized. This is happening because the RB_CLEAR_NODE macro currently expands to rb_set_parent(node, node), which in turn attempts to read the node->rb_parent_color. In certain cases where the node has not yet been initialized, reading the rb_parent_color could return garbage.

This change fixes the issue and clears the warning by updating the RB_CLEAR_NODE macro to directly set the parent pointer without reading the potential garbage color value. The new RB_CLEAR_NODE macro implementation is similar to what is used in the Linux kernel.