### PR TITLE
Add YouTube downloader feature with audio extraction and UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ cmus-y := \
 	job.o keys.o keyval.o lib.o load_dir.o locking.o mergesort.o misc.o options.o \
 	output.o pcm.o player.o play_queue.o pl.o pl_env.o rbtree.o read_wrapper.o \
 	search_mode.o search.o server.o spawn.o tabexp_file.o tabexp.o track_info.o \
-	track.o tree.o uchar.o u_collate.o ui_curses.o window.o worker.o xstrjoin.o
+	track.o tree.o uchar.o u_collate.o ui_curses.o window.o worker.o xstrjoin.o \
+	youtube.o youtube_ui.o
 
 cmus-$(CONFIG_MPRIS) += mpris.o
 

--- a/command_mode.c
+++ b/command_mode.c
@@ -48,8 +48,11 @@
 #include "op.h"
 #include "mpris.h"
 #include "job.h"
+#include "youtube.h"
+#include "youtube_ui.h"
 
 #include <stdlib.h>
+#include <string.h>
 #include <ctype.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -379,6 +382,62 @@ static void cmd_clear(char *arg)
 		return;
 	}
 	view_clear(flag_to_view(flag));
+}
+
+static void cmd_youtube(char *arg)
+{
+	char *subcommand, *url, *ptr;
+	char output_path[512];
+
+	if (!arg || !*arg) {
+		error_msg("usage: :youtube add <url>");
+		return;
+	}
+
+	/* Parse subcommand and URL */
+	subcommand = arg;
+	ptr = strchr(arg, ' ');
+	if (ptr) {
+		*ptr = '\0';
+		url = ptr + 1;
+		/* Skip leading spaces */
+		while (*url == ' ')
+			url++;
+	} else {
+		url = NULL;
+	}
+
+	if (!url || !*url) {
+		error_msg(":youtube requires URL");
+		return;
+	}
+
+	/* Handle different subcommands */
+	if (strcmp(subcommand, "add") == 0) {
+		/* Validate URL first */
+		if (!youtube_url_is_valid(url)) {
+			error_msg("Invalid YouTube URL");
+			return;
+		}
+
+		/* Check if yt-dlp is installed */
+		if (!check_ytdlp_installed()) {
+			error_msg("yt-dlp not installed");
+			return;
+		}
+
+		/* Show download start message */
+		youtube_ui_show_download_start(url);
+
+		/* Start download in background */
+		if (youtube_download(url, output_path, sizeof(output_path)) == 0) {
+			youtube_ui_show_download_complete(output_path);
+		} else {
+			youtube_ui_show_download_error("Download failed");
+		}
+	} else {
+		error_msg("Unknown subcommand: %s. Use 'add'", subcommand);
+	}
 }
 
 static void cmd_load(char *arg)
@@ -2710,6 +2769,7 @@ struct command commands[] = {
 	{ "win-update",            cmd_win_update,       0, 0,  NULL,                 0, 0          },
 	{ "win-update-cache",      cmd_win_update_cache, 0, 1,  NULL,                 0, 0          },
 	{ "wq",                    cmd_quit,             0, 1,  NULL,                 0, 0          },
+	{ "youtube",               cmd_youtube,          1, 1,  NULL,                 0, 0          },
 	{ NULL,                    NULL,                 0, 0,  0,                    0, 0          }
 };
 

--- a/youtube.c
+++ b/youtube.c
@@ -1,0 +1,116 @@
+#include "youtube.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pwd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#define DOWNLOAD_SUBDIR ".config/cmus/downloads"
+#define MAX_CMD_LEN     2048
+#define MAX_PATH_LEN    1024
+
+static int ytdlp_is_installed(void) {
+	return system("which yt-dlp > /dev/null 2>&1") == 0;
+}
+
+static int create_directory_if_not_exists(const char *path) {
+	struct stat st;
+
+	if (stat(path, &st) == -1) {
+		if (mkdir(path, 0755) == -1) {
+			perror("Failed to create directory");
+			return -1;
+		}
+	}
+	return 0;
+}
+
+static char *get_download_path(void) {
+	static char download_path[MAX_PATH_LEN];
+	const char *home;
+
+	home = getenv("HOME");
+	if (!home) {
+		struct passwd *pw = getpwuid(getuid());
+		home = pw ? pw->pw_dir : "/tmp";
+	}
+
+	snprintf(download_path, sizeof(download_path), "%s/%s", home, DOWNLOAD_SUBDIR);
+	return download_path;
+}
+
+int check_ytdlp_installed(void) {
+	if (!ytdlp_is_installed()) {
+		fprintf(stderr, "Error: yt-dlp is not installed. Please install it to use this feature.\n");
+		return 0;
+	}
+	return 1;
+}
+
+int youtube_url_is_valid(const char *url) {
+	if (!url) {
+		fprintf(stderr, "Error: URL is NULL\n");
+		return 0;
+	}
+
+	if (strstr(url, "youtube.com") || strstr(url, "youtu.be")) {
+		return 1;
+	}
+
+	fprintf(stderr, "Error: URL is not a valid YouTube URL\n");
+	return 0;
+}
+
+int youtube_download(const char *url, char *output_path, size_t path_len) {
+	char command[MAX_CMD_LEN];
+	char result_path[MAX_PATH_LEN];
+	const char *download_dir = get_download_path();
+
+	if (!youtube_url_is_valid(url) || !check_ytdlp_installed()) {
+		fprintf(stderr, "Error: Invalid URL or yt-dlp not installed\n");
+		return -1;
+	}
+
+	if (create_directory_if_not_exists(download_dir) == -1) {
+		fprintf(stderr, "Error: Failed to create download directory\n");
+		return -1;
+	}
+
+	snprintf(command, sizeof(command),
+		"yt-dlp -x "
+		"--audio-format opus "
+		"--audio-quality 0 "
+		"-o '%s/%%(title)s.%%(ext)s' "
+		"--print after_move:filepath "
+		"'%s' 2>&1",
+		download_dir, url
+	);
+
+	FILE *pipe = popen(command, "r");
+
+	if (!pipe) {
+		perror("Failed to run yt-dlp command");
+		return -1;
+	}
+
+	if (fgets(result_path, sizeof(result_path), pipe) == NULL) {
+		fprintf(stderr, "Error: Failed to read yt-dlp output\n");
+		pclose(pipe);
+		return -1;
+	}
+
+	int exit_code = pclose(pipe);
+	if (exit_code != 0) {
+		fprintf(stderr, "Error: yt-dlp command failed with exit code %d\n", exit_code);
+		return -1;
+	}
+
+	// Remove trailing newline from result_path
+	result_path[strcspn(result_path, "\n")] = '\0';
+
+	snprintf(output_path, path_len, "%s", result_path);
+	return 0;
+}

--- a/youtube.h
+++ b/youtube.h
@@ -1,0 +1,24 @@
+#ifndef YOUTUBE_H
+#define YOUTUBE_H
+
+#include <stddef.h>
+
+/*
+ * Check if yt-dlp is installed on the system
+ * Returns: 1 if installed, 0 otherwise (error message printed to stderr)
+ */
+int check_ytdlp_installed(void);
+
+/*
+ * Validate if URL is a valid YouTube URL
+ * Returns: 1 if valid YouTube URL, 0 otherwise (error message printed to stderr)
+ */
+int youtube_url_is_valid(const char *url);
+
+/*
+ * Download audio from YouTube URL
+ * Returns: 0 on success, -1 on error
+ */
+int youtube_download(const char *url, char *output_path, size_t path_len);
+
+#endif // YOUTUBE_H

--- a/youtube_ui.c
+++ b/youtube_ui.c
@@ -1,0 +1,50 @@
+#include "youtube_ui.h"
+
+#include <stdio.h>
+#include <stdarg.h>
+
+extern void info_msg(const char *fmt, ...);
+extern void error_msg(const char *fmt, ...);
+
+void youtube_ui_show_download_start(const char *title) {
+	if (!title) {
+		error_msg("youtube_ui: title is NULL");
+		return;
+	}
+
+	fprintf(stderr, "[youtube_ui] Starting download for: %s\n", title);
+	info_msg("YouTube: Downloading '%s'...", title);
+}
+
+void youtube_ui_show_download_complete(const char *filepath) {
+	if (!filepath) {
+		error_msg("youtube_ui: filepath is NULL");
+		return;
+	}
+
+	fprintf(stderr, "[youtube_ui] Download complete - %s\n", filepath);
+	info_msg("YouTube: Downloaded successfully to %s", filepath);
+}
+
+void youtube_ui_show_download_error(const char *error) {
+	if (!error) {
+		error_msg("youtube_ui: error message is NULL");
+		return;
+	}
+
+	fprintf(stderr, "[youtube_ui] Download error - %s\n", error);
+	error_msg("YouTube: Download failed - %s", error);
+}
+
+void youtube_ui_update_progress(int percent) {
+	if (percent < 0 || percent > 100) {
+		fprintf(stderr, "[youtube_ui] Invalid progress value: %d\n", percent);
+		return;
+	}
+
+	fprintf(stderr, "[youtube_ui] Progress - %d%%\n", percent);
+
+	if (percent % 10 == 0 || percent == 100) {
+		info_msg("YouTube: Downloading... %d%%", percent);
+	}
+}

--- a/youtube_ui.h
+++ b/youtube_ui.h
@@ -1,0 +1,49 @@
+/*
+ * YouTube UI Module - youtube_ui.h
+ *
+ * Simple UI functions untuk YouTube download feature.
+ * Menggunakan existing info_msg() dari cmus untuk display.
+ */
+
+#ifndef YOUTUBE_UI_H
+#define YOUTUBE_UI_H
+
+typedef enum {
+	DOWNLOAD_PENDING,
+	DOWNLOAD_IN_PROGRESS,
+	DOWNLOAD_COMPLETED,
+	DOWNLOAD_FAILED
+} download_status;
+
+typedef struct {
+	const char *url;
+	const char *title;
+	download_status status;
+	int progress;  /* 0-100 */
+} youtube_download_info;
+
+/*
+ * Display download status message
+ * Shows: "Downloading: <title>"
+ */
+void youtube_ui_show_download_start(const char *title);
+
+/*
+ * Display download completed message
+ * Shows: "Downloaded: <filepath>"
+ */
+void youtube_ui_show_download_complete(const char *filepath);
+
+/*
+ * Display download error message
+ * Shows: "Download failed: <error_message>"
+ */
+void youtube_ui_show_download_error(const char *error);
+
+/*
+ * Update download progress (optional)
+ * Shows: "Downloading... 50%"
+ */
+void youtube_ui_update_progress(int percent);
+
+#endif /* YOUTUBE_UI_H */


### PR DESCRIPTION
- Implement youtube.c/youtube.h: Download audio from YouTube via yt-dlp
- Implement youtube_ui.c/youtube_ui.h: Display download status messages
- Integrate :youtube command into command_mode.c
- Update Makefile to build YouTube modules

YouTube downloader features:
- URL validation for youtube.com and youtu.be links
- yt-dlp installation check
- Audio extraction in Opus format
- Download directory: ~/.config/cmus/downloads