### PR TITLE
Fix feat. tracks handling in tree view

### DIFF
--- a/lib.c
+++ b/lib.c
@@ -177,16 +177,19 @@ static bool track_exists(struct track_info *ti)
 	struct artist *artist;
 	struct album *album;
 	struct tree_track *track;
+	char * artist_name;
 
 	if (!ti->collkey_title)
 		return false;
 
-	char *artist_collkey_name = u_strcasecoll_key(tree_artist_name(ti));
+	artist_name = tree_artist_name(ti);
+	char *artist_collkey_name = u_strcasecoll_key(artist_name);
 	rb_for_each_entry(artist, node, &lib_artist_root, tree_node) {
 		if (strcmp(artist->collkey_name, artist_collkey_name) == 0)
 			break;
 	}
 	free(artist_collkey_name);
+	free(artist_name);
 
 	if (!artist)
 		return false;

--- a/lib.h
+++ b/lib.h
@@ -136,7 +136,7 @@ struct track_info *lib_get_cur_stored_track(void);
 
 struct tree_track *tree_get_selected(void);
 struct track_info *tree_activate_selected(void);
-const char *tree_artist_name(const struct track_info* ti);
+char *tree_artist_name(const struct track_info* ti);
 const char *tree_album_name(const struct track_info* ti);
 void tree_sort_artists(void (*add_album_cb)(struct album *), void (*remove_album_cb)(struct album *));
 void tree_add_track(struct tree_track *track, void (*add_album_cb)(struct album *));

--- a/tree.c
+++ b/tree.c
@@ -891,14 +891,25 @@ static void album_add_track(struct album *album, struct tree_track *track)
 	rb_insert_color(&track->tree_node, &album->track_root);
 }
 
-const char *tree_artist_name(const struct track_info* ti)
+char *tree_artist_name(const struct track_info* ti)
 {
-	const char *val = ti->albumartist;
+	char *val;
+	const char *found, *artist = ti->albumartist;
 
 	if (ti->is_va_compilation)
-		val = "<Various Artists>";
-	if (!val || strcmp(val, "") == 0)
-		val = "<No Name>";
+		val = xstrdup("<Various Artists>");
+	else if (!artist || strcmp(artist, "") == 0)
+		val = xstrdup("<No Name>");
+	else
+	{
+		  // Assume that artist names separated by comma and first artist is owner of track.
+		  // This needed to prevent creating albums like "Daft Punk, Pharell Williams"
+		  found = strstr(artist, ", ");
+		  if (found)
+			val = xstrndup(artist, found - artist);
+		  else
+			val = xstrdup(artist);
+	}
 
 	return val;
 }
@@ -943,6 +954,7 @@ void tree_add_track(struct tree_track *track,
 	struct album *album, *new_album;
 	int date;
 	int is_va_compilation = 0;
+	bool free_artist_name = false;
 
 	date = ti->originaldate;
 	if (date < 0)
@@ -954,6 +966,7 @@ void tree_add_track(struct tree_track *track,
 	} else {
 		album_name	= tree_album_name(ti);
 		artist_name	= tree_artist_name(ti);
+		free_artist_name = true;
 		artistsort_name	= ti->artistsort;
 		albumsort_name	= ti->albumsort;
 
@@ -1041,6 +1054,9 @@ void tree_add_track(struct tree_track *track,
 
 	if (track_visible(track))
 		window_changed(lib_track_win);
+
+	if (free_artist_name)
+		free((void*)artist_name);
 }
 
 static void remove_sel_artist(struct artist *artist)


### PR DESCRIPTION
Current problem - If track have few artists, then cmus will handle them as one. This is not only bad due to artists with names like "A, B", "A/B", "A featuring B", but also that track will not be shown in A or B album.

There are already few similar issues #1426 #806.

I suggest simple solution for this - assume that there is separator and that first artists is own track and others are featuring artists. So, we can create only artist A and correctly fill it's album.

This is a draft version to start discussion. I hope we will come to something more acceptable. Current addition change old behavior, so, probably, we should hide it under config option with default to old behavior.

Also, I saw @nefthy comment in #806
> Ok now I understand. This is not possible in cmus. The artist in your id3tags is "A / B / C". For cmus this is one artist with that name, not 3 artists. Assigning the song to all artists, requires guesswork ... . I do not think that such a feature would be accepted.

I understand that this is guesswork, etc, but cmus is an application for users, so it should satisfy users needs. Yes, such solution can add code smell, decrease it quality, but I think the most important for app is to *satisfy users need*. If it isn't, code quality doesn't matter. 

> and interpreting tags in ways, that go beyond what the standard says

What standard do you mentioning? If this is [id3v2](https://id3.org/id3v2.3.0), then it allow multiple artists:
> TPE1
>    The 'Lead artist(s)/Lead performer(s)/Soloist(s)/Performing group' is used for the main artist(s). They are seperated with the "/" character. 

But I'm not sure that this is useful here because cmus work not only with id3 tags (I think, I can be wrong).
