### PR TITLE
op/aaudio: fix dsp.aaudio.sharing_mode getter

### DIFF
--- a/op/aaudio.c
+++ b/op/aaudio.c
@@ -449,7 +449,7 @@ static int op_aaudio_set_sharing_mode(const char *val)
 
 static int op_aaudio_get_sharing_mode(char **val)
 {
-	switch (op_aaudio_opt_performance_mode) {
+	switch (op_aaudio_opt_sharing_mode) {
 	default:
 		__attribute__((fallthrough));
 	case AAUDIO_SHARING_MODE_SHARED:


### PR DESCRIPTION
Noticed it while working on a native [Android port](https://github.com/pgaskin/cmus-android).