### PR TITLE
Search in albumsort and artistsort in tree view

### DIFF
--- a/track_info.c
+++ b/track_info.c
@@ -171,8 +171,12 @@ int track_info_has_tag(const struct track_info *ti)
 
 static inline int match_word(const struct track_info *ti, const char *word, unsigned int flags)
 {
-	return ((flags & TI_MATCH_ARTIST) && ti->artist && u_strcasestr_base(ti->artist, word)) ||
-	       ((flags & TI_MATCH_ALBUM) && ti->album && u_strcasestr_base(ti->album, word)) ||
+	return ((flags & TI_MATCH_ARTIST) &&
+				   ((ti->artist && u_strcasestr_base(ti->artist, word))
+				|| ((ti->artistsort && u_strcasestr_base(ti->artistsort, word))))) ||
+	       ((flags & TI_MATCH_ALBUM) &&
+				   ((ti->album && u_strcasestr_base(ti->album, word))
+				|| ((ti->albumsort && u_strcasestr_base(ti->albumsort, word))))) ||
 	       ((flags & TI_MATCH_TITLE) && ti->title && u_strcasestr_base(ti->title, word)) ||
 	       ((flags & TI_MATCH_ALBUMARTIST) && ti->albumartist && u_strcasestr_base(ti->albumartist, word));
 }


### PR DESCRIPTION
It is more intuitive to allow searching by both the displayed name and the sorting name.

I have some music where the artist name is in CJK characters, and it is sorted by the romanized name. Since it's already sorted that way, I think it would be nice to allow the search matching function to also match on the sorted name.
